### PR TITLE
Add basic script-to-rule-them all support; clean up contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,9 +28,14 @@ Busy-Beaver welcomes any, and all, contributions. Every little bit helps!
 
 ## Architecture Overview
 
-Busy-Beaver is a Python application with a Slack frontend. The application consists of a set of REST endpoints with integrations to various services (GitHub, Slack, YouTube, Trello, etc) using public APIs / 3rd party libraries.
+Busy-Beaver is a Python application with a Slack frontend. The application
+consists of a set of REST endpoints with integrations to various services
+(GitHub, Slack, YouTube, Trello, etc) using public APIs / 3rd party libraries.
 
-While the application is currently a monolith, it is built with Service-Oriented Architecture (SOA) in mind. API endpoints are implemented using Flask blueprints and services are integrated using the Adapter / Facade pattern.
+While the application is currently a monolith, it is built with
+Service-Oriented Architecture (SOA) in mind. API endpoints are implemented
+using Flask blueprints and services are integrated using the Adapter / Facade
+pattern.
 
 Busy-Beaver tasks are kicked off through `curl` requests scheduled via CRON.
 
@@ -39,7 +44,15 @@ Busy-Beaver tasks are kicked off through `curl` requests scheduled via CRON.
 The following diagram shows a high-level workflow of the GitHub activity features:
 <img src="assets/architecture.png" width=800 />
 
-> When a Slack user chats "connect" to the bot user via direct message, the server receives the event details and generates a unique `state` identifier. The server logs the Slack user and identifier to our server database. The bot user chats a GitHub URL containing our GitHub app's `client_id` and the `state` identifier. The URL leads the user to a validation page in which they log in to GitHub and approve access to basic public information. Upon approval, the GitHub user's details and `state` identifier are sent to another server endpoint. The server updates the Slack user record with GitHub user details by using the `state` identifier as a common key.
+> When a Slack user chats "connect" to the bot user via direct message, the
+> server receives the event details and generates a unique `state` identifier.
+> The server logs the Slack user and identifier to our server database. The bot
+> user chats a GitHub URL containing our GitHub app's `client_id` and the
+> `state` identifier. The URL leads the user to a validation page in which they
+> log in to GitHub and approve access to basic public information. Upon
+> approval, the GitHub user's details and `state` identifier are sent to
+> another server endpoint. The server updates the Slack user record with GitHub
+> user details by using the `state` identifier as a common key.
 
 #### GitHub Events
 
@@ -56,7 +69,10 @@ Busy Beaver currently supports the following GitHub public events:
 
 ## Development Environment
 
-It is recommended that users create a personal **Slack Workspace** to use for bot development. This will allow for independent development without having to wait for project maintainers to grant access to the Busy-Beaver development Slack.
+It is recommended that users create a personal **Slack Workspace** to use for
+bot development. This will allow for independent development without having to
+wait for project maintainers to grant access to the Busy-Beaver development
+Slack.
 
 ### Slack Integration
 
@@ -65,32 +81,32 @@ An in-depth guide can be followed at <a href=docs/development-create-slack-bot/r
 </td></tr></table></br>
 
 1. [Create a Slack workspace](https://get.slack.help/hc/en-us/articles/206845317-Create-a-Slack-workspace)
-2. [Create a Slack App](https://api.slack.com/apps) and set the **Development Slack Workspace** to the workspace from the previous step - [Create a Slack Dev-Bot - Init a Slack App](docs/development-create-slack-bot/readme.md#init-a-slack-app)
-3. Configure the **Slack App** settings - [Create a Slack Dev-Bot - Slack App Settings](docs/development-create-slack-bot/readme.md#Slack-App-Settings)
-4. Install **Slack App** to **Slack Workspace** - [Create a Slack Dev-Bot - Install App to Workspace](docs/development-create-slack-bot/readme.md#Install-App-to-Workspace)
+2. [Create a Slack App](https://api.slack.com/apps) and set the **Development
+   Slack Workspace** to the workspace from the previous step - [Create a Slack
+   Dev-Bot - Init a Slack
+   App](docs/development-create-slack-bot/readme.md#init-a-slack-app)
+3. Configure the **Slack App** settings - [Create a Slack Dev-Bot - Slack App
+   Settings](docs/development-create-slack-bot/readme.md#Slack-App-Settings)
+4. Install **Slack App** to **Slack Workspace** - [Create a Slack Dev-Bot -
+   Install App to
+   Workspace](docs/development-create-slack-bot/readme.md#Install-App-to-Workspace)
 
 ### Setting up Development Environment
 
+#### Clone the repo with prerequisites
 1. `pip install pre-commit`
 1. Install [Git-LFS](https://git-lfs.github.com/)
 1. Clone repo
 1. `cd <directory of the git repo>`
-1. `cp .env.template .env`
-1. Define the following `.env` config values:
 
-   |Key|Source Value|Details|
-   |---|---|---|
-   |**SLACK_BOTUSER_OAUTH_TOKEN**|From the Dev-Bot Slack App API page under `Install App > OAuth Tokens for Your Team > Bot User OAuth Access Token`| Value obtained after - [Create a Slack Dev-Bot - Define App OAuth and Permissions](docs/development-create-slack-bot/readme.md#Define-App-OAuth-and-Permissions)|
-   |**SLACK_SIGNING_SECRET**|From the Dev-Bot Slack App API page under `Basic Information > App Credentials > Signing Secret`| Value obtained after - [Create a Slack Dev-Bot - Define App OAuth and Permissions](docs/development-create-slack-bot/readme.md#Define-App-OAuth-and-Permissions)|
-   |**NGROK_BASE_URI**|From the **ngrok** instance forwarding address|Value obtained after - [Create a Slack Dev-Bot - Enable Event Subscription](docs/development-create-slack-bot/readme.md#Enable-Event-Subscription)|
-
-   Note: The **NGROK_BASE_URI** and **Slack Event Subscription > Request URL** values may need to be updated each time a new **ngrok** instance is created or if the address is expired.
-
-1. `make up` to refresh environment variables inside of Busy-Beaver
+#### Configure application
+1. `script/setup`
+1. Configure the environment variables in `.env` with your Slack and other configuration values
+1. `script/server` to start Busy-Beaver
 
 ### Verify Installation
 
-1. `make dev-shell`
+1. `script/console`
 1. Try sending a message to a channel for the development **Slack Workspace** with the command:
 
    ```python
@@ -102,67 +118,77 @@ An in-depth guide can be followed at <a href=docs/development-create-slack-bot/r
 
 ### Running Tests
 
-To run the test suite,
-first,
-bring up the service.
-Busy Beaver tests depend on a running database
-and other pieces
-so the following Makefile target will start Docker Compose
-and get the required software going.
+`script/server` - To run the test suite, first, bring up the service.  Busy
+Beaver tests depend on a running database and other pieces so the following
+Makefile target will start Docker Compose and get the required software going.
 
-```bash
-$ make up
-```
-
-Once Docker Compose is running,
-run pytest with:
-
-```bash
-$ make test
-```
+`script/test` - Once Docker Compose is running, run pytest. More advanced test
+configurations are documented in the `Makefile`.
 
 ## Modifying Integration
 
-As each integration requires API credentials, it is recommended that contributors create apps for integration connect to their personal accounts.
+As each integration requires API credentials, it is recommended that
+contributors create apps for integration connect to their personal accounts.
 
 ## Adding New Integration
 
-Provide detailed instructions on how to set up the integration so we can roll the feature out to the production instance of Busy-Beaver with correct credentials.
+Provide detailed instructions on how to set up the integration so we can roll
+the feature out to the production instance of Busy-Beaver with correct
+credentials.
 
 ## Miscellaneous
 
 ### Pre-commit
 
-[Pre-commit](https://pre-commit.com/) is a tool used to enforce linting with `flake8` and code formatting with `black`. To get started using
-pre-commit, `pip install pre-commit==1.14.4` (this is in the `requirements.txt` file). Then run `pre-commit install`
-to install the `flake8` and `black` environments locally.
+[Pre-commit](https://pre-commit.com/) is a tool used to enforce linting with
+`flake8` and code formatting with `black`. To get started using pre-commit,
+`pip install pre-commit==1.14.4` (this is in the `requirements.txt` file). Then
+run `pre-commit install` to install the `flake8` and `black` environments
+locally.
 
-Pre-commit will run on files staged for change automatically. You can also check pre-commit hook compliance on staged
-files by running `pre-commit run` at any time. Note that pre-commit ignores files that are not staged for change.
+Pre-commit will run on files staged for change automatically. You can also
+check pre-commit hook compliance on staged files by running `pre-commit run` at
+any time. Note that pre-commit ignores files that are not staged for change.
 
 ### Task Queues
 
-Busy Beaver uses [RQ](http://python-rq.org) to queue jobs and process them in the background with workers. [Redis](https://redis.io/) is used as the message broker in this asynchronous architecture.
+Busy Beaver uses [RQ](http://python-rq.org) to queue jobs and process them in
+the background with workers. [Redis](https://redis.io/) is used as the message
+broker in this asynchronous architecture.
 
-The Docker Compose development environment spins up a single worker along with a Redis instance. For testing purposes, we set `is_async=False` to force code to be executed synchronously. Need to find a way to simulate production environment with workers in Travis, or it might make sense to migrate to Jenkins.
+The Docker Compose development environment spins up a single worker along with
+a Redis instance. For testing purposes, we set `is_async=False` to force code
+to be executed synchronously. Need to find a way to simulate production
+environment with workers in Travis, or it might make sense to migrate to
+Jenkins.
 
 #### Creating a New Task
 
 1. Create a SQLAlchemy model to store task-specific information to the database
 1. Run a database migration, `$ make migration m="migration message"`
-1. Create two functions: background job function (decorated with `@rq.job`) and trigger function to start background job
-1. In the trigger function, start the background job and save job specific information to the database
-1. Write tests unti you have confidence that your code works and can be reviewed by others
+1. Create two functions: background job function (decorated with `@rq.job`) and
+   trigger function to start background job
+1. In the trigger function, start the background job and save job specific
+   information to the database
+1. Write tests unti you have confidence that your code works and can be
+   reviewed by others
 
 #### Notes
 
-- The [Flask-RQ](https://flask-rq2.readthedocs.io/en/latest/) library provides convenient, Flask-specific helpers. Background tasks are identified using the `@rq.job` decorator; jobs can be created using the `[background_task_function_name].queue(params)` method.
-- Both the trigger function and background task are unit tested to ensure things occur as expected. A high-level integration test can help codify the requirements of the workflow.
-- Currently the workers listen on the `default` and `failed` queues. No particular reason, but haven't had the needed to use other queues.
+- The [Flask-RQ](https://flask-rq2.readthedocs.io/en/latest/) library provides
+  convenient, Flask-specific helpers. Background tasks are identified using the
+  `@rq.job` decorator; jobs can be created using the
+  `[background_task_function_name].queue(params)` method.
+- Both the trigger function and background task are unit tested to ensure
+  things occur as expected. A high-level integration test can help codify the
+  requirements of the workflow.
+- Currently the workers listen on the `default` and `failed` queues. No
+  particular reason, but haven't had the needed to use other queues.
 
 ### PDB++ Configuration
 
-[PDB++](https://pypi.org/project/pdbpp/) improves the debugging experience inside the shell. Create a `.pdbrc.py` file inside of the root project folder.
+[PDB++](https://pypi.org/project/pdbpp/) improves the debugging experience
+inside the shell. Create a `.pdbrc.py` file inside of the root project folder.
 
 ```python
 # ./.pdbrc.py

--- a/sample.env
+++ b/sample.env
@@ -1,0 +1,19 @@
+# From the **ngrok** instance forwarding address|Value obtained after -
+# Create a Slack Dev-Bot - Enable Event Subscription
+# Go to docs/development-create-slack-bot/readme.md#Enable-Event-Subscription
+#
+# Note: The **NGROK_BASE_URI** and **Slack Event Subscription > Request URL**
+# values may need to be updated each time a new **ngrok** instance is created
+# or if the address is expired.
+NGROK_BASE_URI=
+
+# From the Dev-Bot Slack App API page under Install App > OAuth Tokens for
+# Your Team > Bot User OAuth Access Token
+# Value obtained after - Create a Slack Dev-Bot - Define App OAuth and Permissions
+# Go to docs/development-create-slack-bot/readme.md#Define-App-OAuth-and-Permissions
+SLACK_BOTUSER_OATH_TOKEN=
+
+#From the Dev-Bot Slack App API page under `Basic Information > App Credentials > Signing Secret`
+#Value obtained after - Create a Slack Dev-Bot - Define App OAuth and Permissions
+#Go to docs/development-create-slack-bot/readme.md#Define-App-OAuth-and-Permissions
+SLACK_SIGNING_SECRET=

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+pip install -r requirements.txt

--- a/script/console
+++ b/script/console
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker-compose exec app ipython -i scripts/dev/shell.py

--- a/script/console-os
+++ b/script/console-os
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker-compose exec app bash

--- a/script/server
+++ b/script/server
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+docker-compose down
+
+docker-compose up -d
+make migrate-up

--- a/script/setup
+++ b/script/setup
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+import os
+import shutil
+import subprocess
+
+project_root = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
+
+subprocess.call([os.path.join(project_root, 'script', 'bootstrap')])
+
+env_filepath = os.path.join(project_root, '.env')
+if not os.path.exists(env_filepath):
+    print('Copying sample.env to .env; you MUST update with your values!')
+    shutil.copyfile(os.path.join(project_root, 'sample.env'), env_filepath)
+
+print('Building docker images')
+subprocess.call(['docker-compose', 'build'])

--- a/script/test
+++ b/script/test
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+import os
+import subprocess
+import sys
+
+def docker_container_is_running(container_name):
+    stdout = subprocess.check_output(['docker', 'ps'])
+    return container_name in stdout.decode('utf-8')
+
+if not docker_container_is_running('app'):
+    project_root = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
+    subprocess.call([os.path.join(project_root, 'script', 'server')])
+
+args = ['docker-compose', 'exec', 'app', 'pytest']
+if len(sys.argv) > 1:
+    args += sys.argv[1:]
+
+print("Executing: {}".format(' '.join(args)))
+subprocess.call(args)


### PR DESCRIPTION
## Problem

The setup process was a little confusing. Mostly, I really want to be able to start coding in a few commands.

## Solution
[Github Scripts To Rule Them All](https://github.com/github/scripts-to-rule-them-all) is a really awesome way to allow for customization while still standardizing on the core stuff all devs will need to do. Primarily? `script/setup` gets you started and `script/test` gets your running the test suite, regardless of anything else.

To do this (and to make it work on Windows and Mac) I went with some Python scripts where shell agnostic bash scripts weren't as portable. 

Beyond that, adhering to the 80character standard for README's makes it much more readable as you're walking through the guide in a text editor (no HTML rendered effect). 

## Note

I used the true standard of `script/`, which is a lot like your `scripts/`. I advise adhering to the standard, but if it's preferable `scripts/` is a fine compromise. 


@ryansmccoy 