### PR TITLE
Refactor Event Subscription to Slash Command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,8 +17,8 @@ Busy Beaver welcomes any, and all, contributions. Every little bit helps!
 - [Adding New Third-Party Integrations](#adding-new-third-party-integrations)
 - [Miscellaneous](#miscellaneous)
   - [Pre-commit](#pre-commit)
-  - [Task Queues](#task-queues)
   - [Slack Slash Commands](#slack-slash-commands)
+  - [Task Queues](#task-queues)
   - [PDB++ Configuration](#pdb-configuration)
 
 <!-- /TOC -->
@@ -137,12 +137,6 @@ to install the `flake8` and `black` environments locally.
 Pre-commit will run on files staged for change automatically. You can also check pre-commit hook compliance on staged
 files by running `pre-commit run` at any time. Note that pre-commit ignores files that are not staged for change.
 
-### Task Queues
-
-Busy Beaver uses [RQ](http://python-rq.org) to queue jobs and process them in the background with workers. [Redis](https://redis.io/) is used as the message broker in this asynchronous architecture.
-
-The Docker Compose development environment spins up a single worker along with a Redis instance. For testing purposes, we set `is_async=False` to force code to be executed synchronously. Need to find a way to simulate production environment with workers in Travis, or it might make sense to migrate to Jenkins.
-
 ### Slack Slash Commands
 
 Users are able to interact with Busy Beaver using the `/busybeaver [command]` interface provided through the Slack UI. All slash commands are routed to a Busy Beaver endpoint that was enabled earlier via the Slack Slash Command webhook.
@@ -158,6 +152,12 @@ def fetch_news(**data):
 ```
 
 - [Slack Docs: Slash Commands](https://api.slack.com/slash-commands)
+
+### Task Queues
+
+Busy Beaver uses [RQ](http://python-rq.org) to queue jobs and process them in the background with workers. [Redis](https://redis.io/) is used as the message broker in this asynchronous architecture.
+
+The Docker Compose development environment spins up a single worker along with a Redis instance. For testing purposes, we set `is_async=False` to force code to be executed synchronously. Need to find a way to simulate production environment with workers in Travis, or it might make sense to migrate to Jenkins.
 
 #### Creating a New Task
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,11 +13,12 @@ Busy Beaver welcomes any, and all, contributions. Every little bit helps!
   - [Setting up Development Environment](#setting-up-development-environment)
   - [Verify Installation](#verify-installation)
   - [Running Tests](#running-tests)
-- [Modifying Integration](#modifying-integration)
-- [Adding New Integration](#adding-new-integration)
+- [Modifying Third-Party Integrations](#modifying-third-party-integrations)
+- [Adding New Third-Party Integrations](#adding-new-third-party-integrations)
 - [Miscellaneous](#miscellaneous)
   - [Pre-commit](#pre-commit)
   - [Task Queues](#task-queues)
+  - [Slack Slash Commands](#slack-slash-commands)
   - [PDB++ Configuration](#pdb-configuration)
 
 <!-- /TOC -->
@@ -61,9 +62,9 @@ An in-depth guide can be followed at <a href=docs/development-create-slack-bot/r
 </td></tr></table></br>
 
 1. [Create a Slack workspace](https://get.slack.help/hc/en-us/articles/206845317-Create-a-Slack-workspace)
-2. [Create a Slack App](https://api.slack.com/apps) and set the **Development Slack Workspace** to the workspace from the previous step - [Create a Slack Dev-Bot - Init a Slack App](docs/development-create-slack-bot/readme.md#init-a-slack-app)
-3. Configure the **Slack App** settings - [Create a Slack Dev-Bot - Slack App Settings](docs/development-create-slack-bot/readme.md#Slack-App-Settings)
-4. Install **Slack App** to **Slack Workspace** - [Create a Slack Dev-Bot - Install App to Workspace](docs/development-create-slack-bot/readme.md#Install-App-to-Workspace)
+1. [Create a Slack App](https://api.slack.com/apps) and set the **Development Slack Workspace** to the workspace from the previous step - [Create a Slack Dev-Bot - Init a Slack App](docs/development-create-slack-bot/readme.md#init-a-slack-app)
+1. Configure the **Slack App** settings - [Create a Slack Dev-Bot - Slack App Settings](docs/development-create-slack-bot/readme.md#Slack-App-Settings)
+1. Install **Slack App** to **Slack Workspace** - [Create a Slack Dev-Bot - Install App to Workspace](docs/development-create-slack-bot/readme.md#Install-App-to-Workspace)
 
 ### Setting up Development Environment
 
@@ -117,11 +118,11 @@ run pytest with:
 $ make test
 ```
 
-## Modifying Integration
+## Modifying Third-Party Integrations
 
 As each integration requires API credentials, it is recommended that contributors create apps for integration connect to their personal accounts.
 
-## Adding New Integration
+## Adding New Third-Party Integrations
 
 Provide detailed instructions on how to set up the integration so we can roll the feature out to the production instance of Busy Beaver with correct credentials.
 
@@ -141,6 +142,22 @@ files by running `pre-commit run` at any time. Note that pre-commit ignores file
 Busy Beaver uses [RQ](http://python-rq.org) to queue jobs and process them in the background with workers. [Redis](https://redis.io/) is used as the message broker in this asynchronous architecture.
 
 The Docker Compose development environment spins up a single worker along with a Redis instance. For testing purposes, we set `is_async=False` to force code to be executed synchronously. Need to find a way to simulate production environment with workers in Travis, or it might make sense to migrate to Jenkins.
+
+### Slack Slash Commands
+
+Users are able to interact with Busy Beaver using the `/busybeaver [command]` interface provided through the Slack UI. All slash commands are routed to a Busy Beaver endpoint that was enabled earlier via the Slack Slash Command webhook.
+
+Busy Beaver uses the [dictionary dispatch pattern](https://alysivji.github.io/quick-hit-dictionary-dispatch.html) to run command-specific logic. We leverage a `EventEmitter` class, inspired by the [node.js EventEmitter](https://nodejs.org/api/events.html#events_class_eventemitter), to allow for the creation of new slash commands with a simple decorator interface.
+
+You can create a custom slash command, i.e. `/busybeaver news`, as follows:
+
+```python
+@slash_command_dispatcher.on("news")
+def fetch_news(**data):
+    # business logic to handle command goes here
+```
+
+- [Slack Docs: Slash Commands](https://api.slack.com/slash-commands)
 
 #### Creating a New Task
 

--- a/busy_beaver/blueprints/integration/__init__.py
+++ b/busy_beaver/blueprints/integration/__init__.py
@@ -1,7 +1,7 @@
 from flask import blueprints
 
 from .github import GitHubIdentityVerificationCallbackResource
-from .slack import SlackEventSubscriptionResource, SlackSlashCommandDispatcher
+from .slack import SlackEventSubscriptionResource, SlackSlashCommandDispatchResource
 from busy_beaver.config import SLACK_SIGNING_SECRET
 from busy_beaver.decorators import verify_slack_signature
 
@@ -13,7 +13,7 @@ integration_bp.add_url_rule(
     "/slack-event-subscription", view_func=slack_verification_required(view)
 )
 
-view = SlackSlashCommandDispatcher.as_view("slack_slash_command_dispatcher")
+view = SlackSlashCommandDispatchResource.as_view("slack_slash_command_dispatcher")
 integration_bp.add_url_rule(
     "/slack-slash-commands", view_func=slack_verification_required(view)
 )

--- a/busy_beaver/blueprints/integration/slack.py
+++ b/busy_beaver/blueprints/integration/slack.py
@@ -24,7 +24,7 @@ UNKNOWN_COMMAND = (
 )
 ACCOUNT_ALREADY_ASSOCIATED = (
     "You have already associated a GitHub account with your Slack handle. "
-    "Please type `reconnect` to link to a different account."
+    "Please try `/busybeaver reconnect` to link to a different account."
 )
 VERIFY_ACCOUNT = (
     "Follow the link below to validate your GitHub account. "
@@ -150,7 +150,7 @@ def link_github(**data):
     user.slack_id = slack_id
     user = add_tracking_identifer_and_save_record(user)
     attachment = create_github_account_attachment(user.github_state)
-    return make_slack_response(attachment=attachment)
+    return make_slack_response(attachments=attachment)
 
 
 @slash_command_dispatcher.on("reconnect")

--- a/busy_beaver/blueprints/integration/slack.py
+++ b/busy_beaver/blueprints/integration/slack.py
@@ -24,7 +24,10 @@ UNKNOWN_COMMAND = (
 )
 ACCOUNT_ALREADY_ASSOCIATED = (
     "You have already associated a GitHub account with your Slack handle. "
-    "Please try `/busybeaver reconnect` to link to a different account."
+    "Please use `/busybeaver reconnect` to link to a different account."
+)
+NO_ASSOCIATED_ACCOUNT = (
+    "No associated account. Please use `/busybeaver connect` to link your account."
 )
 VERIFY_ACCOUNT = (
     "Follow the link below to validate your GitHub account. "
@@ -161,7 +164,7 @@ def relink_github(**data):
 
     if not user_record:
         logger.info("[Busy Beaver] Slack acount does not have associated GitHub")
-        return make_slack_response(text="No associated GitHub account")
+        return make_slack_response(text=NO_ASSOCIATED_ACCOUNT)
 
     user = add_tracking_identifer_and_save_record(user_record)
     attachment = create_github_account_attachment(user.github_state)

--- a/busy_beaver/blueprints/integration/slack.py
+++ b/busy_beaver/blueprints/integration/slack.py
@@ -15,13 +15,6 @@ from busy_beaver.toolbox import EventEmitter, make_slack_response
 logger = logging.getLogger(__name__)
 slash_command_dispatcher = EventEmitter()
 
-SEND_LINK_COMMANDS = ["connect"]
-RESEND_LINK_COMMANDS = ["reconnect"]
-ALL_LINK_COMMANDS = SEND_LINK_COMMANDS + RESEND_LINK_COMMANDS
-
-UNKNOWN_COMMAND = (
-    "I don't recognize your command. Type `connect` to link your GitHub account."
-)
 ACCOUNT_ALREADY_ASSOCIATED = (
     "You have already associated a GitHub account with your Slack handle. "
     "Please use `/busybeaver reconnect` to link to a different account."
@@ -33,7 +26,7 @@ VERIFY_ACCOUNT = (
     "Follow the link below to validate your GitHub account. "
     "I'll reference your GitHub username to track your public activity."
 )
-BOT_RESPONSE_TO_SLASH = "Find all available Busy Beaver Commands using /busybeaver help"
+BOT_RESPONDS_TO_SLASH = "Find all available Busy Beaver Commands using /busybeaver help"
 
 
 class SlackEventSubscriptionResource(MethodView):
@@ -56,7 +49,7 @@ class SlackEventSubscriptionResource(MethodView):
 
         dm_to_bot = event["channel_type"] == "im"
         if event["type"] == "message" and dm_to_bot:
-            slack.post_message(BOT_RESPONSE_TO_SLASH, channel_id=event["channel"])
+            slack.post_message(BOT_RESPONDS_TO_SLASH, channel_id=event["channel"])
         return jsonify(None)
 
 

--- a/busy_beaver/blueprints/integration/slack.py
+++ b/busy_beaver/blueprints/integration/slack.py
@@ -26,7 +26,12 @@ VERIFY_ACCOUNT = (
     "Follow the link below to validate your GitHub account. "
     "I'll reference your GitHub username to track your public activity."
 )
-BOT_RESPONDS_TO_SLASH = "Find all available Busy Beaver Commands using /busybeaver help"
+HELP_TEXT = (
+    "`/busybeaver next`\t\t Retrieve next event\n "
+    "`/busybeaver connect`\t\t Associate GitHub Account\n "
+    "`/busybeaver reconnect`\t\t Reassociate GitHub Account\n "
+    "`/busybeaver help`\t\t Display help text"
+)
 
 
 class SlackEventSubscriptionResource(MethodView):
@@ -49,7 +54,7 @@ class SlackEventSubscriptionResource(MethodView):
 
         dm_to_bot = event["channel_type"] == "im"
         if event["type"] == "message" and dm_to_bot:
-            slack.post_message(BOT_RESPONDS_TO_SLASH, channel_id=event["channel"])
+            slack.post_message(HELP_TEXT, channel_id=event["channel"])
         return jsonify(None)
 
 
@@ -166,12 +171,10 @@ def create_next_event_attachment(event: dict) -> dict:
 ########################
 @slash_command_dispatcher.on("help")
 def display_help_text(**data):
-    return make_slack_response(
-        text="/busybeaver next to upcoming event /busybeaver help to see help text"
-    )
+    return make_slack_response(text=HELP_TEXT)
 
 
 @slash_command_dispatcher.on("not_found")
 def command_not_found(**data):
     logger.info("[Busy Beaver] Unknown command")
-    return make_slack_response(text="Command not found")
+    return make_slack_response(text="Command not found. Try `/busybeaver help`")

--- a/busy_beaver/blueprints/integration/slack/__init__.py
+++ b/busy_beaver/blueprints/integration/slack/__init__.py
@@ -1,0 +1,2 @@
+from .event_subscription import SlackEventSubscriptionResource  # noqa
+from .slash_command import SlackSlashCommandDispatchResource  # noqa

--- a/busy_beaver/blueprints/integration/slack/event_subscription.py
+++ b/busy_beaver/blueprints/integration/slack/event_subscription.py
@@ -1,0 +1,33 @@
+import logging
+
+from flask import jsonify, request
+from flask.views import MethodView
+
+from .slash_command import HELP_TEXT
+from busy_beaver import slack
+
+logger = logging.getLogger(__name__)
+
+
+class SlackEventSubscriptionResource(MethodView):
+    """Callback endpoint for Slack event subscriptions"""
+
+    def post(self):
+        data = request.json
+        logger.info("[Busy Beaver] Received event from Slack", extra={"req_json": data})
+
+        verification_request = data["type"] == "url_verification"
+        if verification_request:
+            logger.info("[Busy Beaver] Slack -- API Verification")
+            return jsonify({"challenge": data["challenge"]})
+
+        # bot can see its own DMs
+        event = data["event"]
+        msg_from_bot = event.get("subtype") == "bot_message"
+        if event["type"] == "message" and msg_from_bot:
+            return jsonify(None)
+
+        dm_to_bot = event["channel_type"] == "im"
+        if event["type"] == "message" and dm_to_bot:
+            slack.post_message(HELP_TEXT, channel_id=event["channel"])
+        return jsonify(None)

--- a/busy_beaver/tasks/github_stats/event_list.py
+++ b/busy_beaver/tasks/github_stats/event_list.py
@@ -42,6 +42,7 @@ class EventList:
 
 class CommitsList(EventList):
     EMOJI = ":arrow_up:"
+    NOUN = "repo"
 
     @staticmethod
     def matches_event(event):
@@ -61,7 +62,7 @@ class CommitsList(EventList):
 
 class CreatedReposList(EventList):
     EMOJI = ":sparkles:"
-    NOUN = "new issue"
+    NOUN = "new repo"
 
     @staticmethod
     def matches_event(event):

--- a/busy_beaver/toolbox/__init__.py
+++ b/busy_beaver/toolbox/__init__.py
@@ -1,2 +1,2 @@
 from .event_emitter import EventEmitter  # noqa
-from .helpers import make_response, utc_now_minus  # noqa
+from .helpers import make_response, make_slack_response, utc_now_minus  # noqa

--- a/busy_beaver/toolbox/helpers.py
+++ b/busy_beaver/toolbox/helpers.py
@@ -1,12 +1,8 @@
 from datetime import datetime, timedelta
 import json as _json
 
-from flask import Response
+from flask import jsonify, Response
 import pytz
-
-
-def utc_now_minus(period: timedelta):
-    return pytz.utc.localize(datetime.utcnow()) - period
 
 
 def make_response(
@@ -29,3 +25,17 @@ def make_response(
         content_type="application/json",
         response=_json.dumps(resp),
     )
+
+
+def make_slack_response(response_type="ephemeral", text="", attachments=None):
+    return jsonify(
+        {
+            "response_type": response_type,
+            "text": text,
+            "attachments": [attachments] if attachments else [],
+        }
+    )
+
+
+def utc_now_minus(period: timedelta):
+    return pytz.utc.localize(datetime.utcnow()) - period

--- a/docs/development-create-slack-bot/images/slash-commands-1.png
+++ b/docs/development-create-slack-bot/images/slash-commands-1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1dc733c3e1b63bd2c768893d60d7ee7f529ed1d5ed19f7b3956ca560f70be808
+size 138780

--- a/docs/development-create-slack-bot/images/slash-commands-2.png
+++ b/docs/development-create-slack-bot/images/slash-commands-2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c8dc58f395f0853c3eb11391380a94de726e58a2098d223a6eb428e05dc66db3
+size 158091

--- a/docs/development-create-slack-bot/readme.md
+++ b/docs/development-create-slack-bot/readme.md
@@ -107,6 +107,22 @@ This will be used for the **slack-event-subscription endpoint** by the local Bus
 :link: Update the <strong>.env</strong> config - <strong>NGROK_BASE_URI</strong> value to <strong>Slack Event Subscription - Request URL</strong> as defined in  <a href=../../CONTRIBUTING.md#Setting-up-Development-Environment>Setting up Development Environment</a>.
 </td></tr></table>
 
+### Enable Slash Commands
+
+1. Create new **Slash Command**.</br>
+   <a href="images/slash-commands-1.png">
+   <img src="images/slash-commands-1.png" width=400/>
+   </a>
+1. Update the **Request URL** to the **slack-slash-command endpoint** composed of the **forwarding address** defined by the **ngrok** instance i.e.
+
+   ```http
+   http://[ngrok_fowarding_address]/slack-slash-command
+   ```
+
+   <a href="images/slash-commands-2.png">
+   <img src="images/slash-commands-2.png" width=400/>
+   </a>
+
 ## Install App to Workspace
 
 Once a feature or permission has been installed,

--- a/tests/blueprints/integration/slack/conftest.py
+++ b/tests/blueprints/integration/slack/conftest.py
@@ -1,0 +1,32 @@
+from collections import OrderedDict
+import json
+from urllib.parse import urlencode
+
+import pytest
+
+from busy_beaver.config import SLACK_SIGNING_SECRET
+from busy_beaver.decorators.verification import calculate_signature
+
+
+@pytest.fixture
+def create_slack_headers():
+    """Dictionary get sorted when we retrieve the body, account for this"""
+
+    def sort_dict(original_dict):
+        res = OrderedDict()
+        for k, v in sorted(original_dict.items()):
+            if isinstance(v, dict):
+                res[k] = dict(sort_dict(v))
+            else:
+                res[k] = v
+        return dict(res)
+
+    def wrapper(timestamp, data, is_json_data=True):
+        if is_json_data:
+            request_body = json.dumps(sort_dict(data)).encode("utf-8")
+        else:
+            request_body = urlencode(data).encode("utf-8")
+        sig = calculate_signature(SLACK_SIGNING_SECRET, timestamp, request_body)
+        return {"X-Slack-Request-Timestamp": timestamp, "X-Slack-Signature": sig}
+
+    return wrapper

--- a/tests/blueprints/integration/slack/event_subscription_test.py
+++ b/tests/blueprints/integration/slack/event_subscription_test.py
@@ -1,0 +1,81 @@
+import pytest
+
+MODULE_TO_TEST = "busy_beaver.blueprints.integration.slack.event_subscription"
+
+
+@pytest.fixture
+def patched_slack(patcher):
+    def _wrapper(replacement):
+        return patcher(MODULE_TO_TEST, namespace="slack", replacement=replacement)
+
+    return _wrapper
+
+
+@pytest.mark.integration
+def test_slack_callback_url_verification(
+    client, session, patched_slack, create_slack_headers
+):
+    # Arrange
+    challenge_code = "test_code"
+    data = {"type": "url_verification", "challenge": challenge_code}
+    headers = create_slack_headers(100_000_000, data)
+
+    # Act
+    resp = client.post("/slack-event-subscription", headers=headers, json=data)
+
+    # Assert
+    assert resp.status_code == 200
+    assert resp.json == {"challenge": challenge_code}
+
+
+@pytest.mark.integration
+def test_slack_callback_bot_message_is_ignored(
+    mocker, client, session, patched_slack, create_slack_headers
+):
+    """Bot get notified of its own DM replies to users... ignore"""
+    # Arrange
+    slack = patched_slack(mocker.MagicMock())
+    data = {
+        "type": "unknown todo",
+        "event": {"type": "message", "subtype": "bot_message"},
+    }
+    headers = create_slack_headers(100_000_000, data)
+
+    # Act
+    resp = client.post("/slack-event-subscription", headers=headers, json=data)
+
+    # Assert
+    assert resp.status_code == 200
+    assert len(slack.mock_calls) == 0
+
+
+@pytest.mark.integration
+def test_slack_callback_user_dms_bot_reply(
+    mocker, client, session, patched_slack, create_slack_headers
+):
+    """When user messages bot, reply with help text"""
+    # Arrange
+    slack = patched_slack(mocker.MagicMock())
+    channel_id = 5
+    data = {
+        "type": "unknown todo",
+        "event": {
+            "type": "message",
+            "subtype": "not bot_message",
+            "channel_type": "im",
+            "text": "random",
+            "user": "random_user",
+            "channel": channel_id,
+        },
+    }
+    headers = create_slack_headers(100_000_000, data)
+
+    # Act
+    resp = client.post("/slack-event-subscription", headers=headers, json=data)
+
+    # Assert
+    assert resp.status_code == 200
+    assert len(slack.mock_calls) == 1
+    args, kwargs = slack.post_message.call_args
+    assert "/busybeaver help" in args[0]
+    assert kwargs["channel_id"] == channel_id

--- a/tests/blueprints/integration/slack/slash_command_test.py
+++ b/tests/blueprints/integration/slack/slash_command_test.py
@@ -1,21 +1,15 @@
-from collections import OrderedDict
-import json
-from urllib.parse import urlencode
-
 import pytest
 
-from busy_beaver.blueprints.integration.slack import (
+from busy_beaver.blueprints.integration.slack.slash_command import (
     command_not_found,
     display_help_text,
     link_github,
     next_event,
     relink_github,
 )
-from busy_beaver.config import SLACK_SIGNING_SECRET
 from busy_beaver.models import User
-from busy_beaver.decorators.verification import calculate_signature
 
-MODULE_TO_TEST = "busy_beaver.blueprints.integration.slack"
+MODULE_TO_TEST = "busy_beaver.blueprints.integration.slack.slash_command"
 
 
 @pytest.fixture
@@ -29,114 +23,6 @@ def add_user(session):
     return _add_user
 
 
-################################
-# Slack Event Subscription Tests
-################################
-@pytest.fixture
-def patched_slack(patcher):
-    def _wrapper(replacement):
-        return patcher(MODULE_TO_TEST, namespace="slack", replacement=replacement)
-
-    return _wrapper
-
-
-@pytest.fixture
-def create_slack_headers():
-    """Dictionary get sorted when we retrieve the body, account for this"""
-
-    def sort_dict(original_dict):
-        res = OrderedDict()
-        for k, v in sorted(original_dict.items()):
-            if isinstance(v, dict):
-                res[k] = dict(sort_dict(v))
-            else:
-                res[k] = v
-        return dict(res)
-
-    def wrapper(timestamp, data, is_json_data=True):
-        if is_json_data:
-            request_body = json.dumps(sort_dict(data)).encode("utf-8")
-        else:
-            request_body = urlencode(data).encode("utf-8")
-        sig = calculate_signature(SLACK_SIGNING_SECRET, timestamp, request_body)
-        return {"X-Slack-Request-Timestamp": timestamp, "X-Slack-Signature": sig}
-
-    return wrapper
-
-
-@pytest.mark.integration
-def test_slack_callback_url_verification(
-    client, session, patched_slack, create_slack_headers
-):
-    # Arrange
-    challenge_code = "test_code"
-    data = {"type": "url_verification", "challenge": challenge_code}
-    headers = create_slack_headers(100_000_000, data)
-
-    # Act
-    resp = client.post("/slack-event-subscription", headers=headers, json=data)
-
-    # Assert
-    assert resp.status_code == 200
-    assert resp.json == {"challenge": challenge_code}
-
-
-@pytest.mark.integration
-def test_slack_callback_bot_message_is_ignored(
-    mocker, client, session, patched_slack, create_slack_headers
-):
-    """Bot get notified of its own DM replies to users... ignore"""
-    # Arrange
-    slack = patched_slack(mocker.MagicMock())
-    data = {
-        "type": "unknown todo",
-        "event": {"type": "message", "subtype": "bot_message"},
-    }
-    headers = create_slack_headers(100_000_000, data)
-
-    # Act
-    resp = client.post("/slack-event-subscription", headers=headers, json=data)
-
-    # Assert
-    assert resp.status_code == 200
-    assert len(slack.mock_calls) == 0
-
-
-@pytest.mark.integration
-def test_slack_callback_user_dms_bot_reply(
-    mocker, client, session, patched_slack, create_slack_headers
-):
-    """When user messages bot, reply with help text"""
-    # Arrange
-    slack = patched_slack(mocker.MagicMock())
-    channel_id = 5
-    data = {
-        "type": "unknown todo",
-        "event": {
-            "type": "message",
-            "subtype": "not bot_message",
-            "channel_type": "im",
-            "text": "random",
-            "user": "random_user",
-            "channel": channel_id,
-        },
-    }
-    headers = create_slack_headers(100_000_000, data)
-
-    # Act
-    resp = client.post("/slack-event-subscription", headers=headers, json=data)
-
-    # Assert
-    assert resp.status_code == 200
-    assert len(slack.mock_calls) == 1
-    args, kwargs = slack.post_message.call_args
-    assert "/busybeaver help" in args[0]
-    assert kwargs["channel_id"] == channel_id
-
-
-###########################
-# Slack Slash Command Tests
-###########################
 @pytest.fixture
 def generate_slash_command_request():
     def _generate_data(
@@ -162,6 +48,9 @@ def generate_slash_command_request():
     return _generate_data
 
 
+###################
+# Integration Tests
+###################
 @pytest.mark.integration
 def test_slack_command_valid_command(
     client, create_slack_headers, generate_slash_command_request

--- a/tests/blueprints/integration/slack_test.py
+++ b/tests/blueprints/integration/slack_test.py
@@ -4,7 +4,12 @@ from urllib.parse import urlencode
 
 import pytest
 
-from busy_beaver.blueprints.integration.slack import link_github, relink_github
+from busy_beaver.blueprints.integration.slack import (
+    command_not_found,
+    display_help_text,
+    link_github,
+    relink_github,
+)
 from busy_beaver.config import SLACK_SIGNING_SECRET
 from busy_beaver.models import User
 from busy_beaver.decorators.verification import calculate_signature
@@ -234,3 +239,15 @@ def test_reconnect_command_existing_user(add_user):
         "Associate GitHub Profile"
         in result.json["attachments"][0]["actions"][0]["text"]
     )
+
+
+def test_command_help():
+    result = display_help_text()
+
+    assert "/busybeaver help" in result.json["text"]
+
+
+def test_command_not_found():
+    result = command_not_found()
+
+    assert "/busybeaver help" in result.json["text"]

--- a/tests/blueprints/integration/slack_test.py
+++ b/tests/blueprints/integration/slack_test.py
@@ -10,6 +10,7 @@ from busy_beaver.blueprints.integration.slack import (
     VERIFY_ACCOUNT,
     reply_to_user_with_github_login_link,
     link_github,
+    relink_github,
 )
 from busy_beaver.config import SLACK_SIGNING_SECRET
 from busy_beaver.models import User
@@ -295,3 +296,23 @@ def test_connect_command_existing_user(add_user):
     result = link_github(**data)
 
     assert "/busybeaver reconnect" in result.json["text"]
+
+
+def test_reconnect_command_new_user(session):
+    data = {"user_id": "new_user"}
+
+    result = relink_github(**data)
+
+    assert "/busybeaver connect" in result.json["text"]
+
+
+def test_reconnect_command_existing_user(add_user):
+    add_user(username="existing_user")
+    data = {"user_id": "existing_user"}
+
+    result = relink_github(**data)
+
+    assert (
+        "Associate GitHub Profile"
+        in result.json["attachments"][0]["actions"][0]["text"]
+    )

--- a/tests/blueprints/integration/slack_test.py
+++ b/tests/blueprints/integration/slack_test.py
@@ -161,7 +161,9 @@ def test_slack_command_invalid_command(client, create_slack_headers):
     assert "command not found" in response.json["text"].lower()
 
 
-# Next Event Slash Commands
+#########################
+# Upcoming Event Schedule
+#########################
 @pytest.fixture
 def patched_meetup(mocker, patcher):
     class FakeMeetupClient:
@@ -205,6 +207,9 @@ def test_command_next_event(patched_meetup):
     assert "http://meetup.com/_ChiPy_/event/blah" in slack_response["title_link"]
 
 
+##########################################
+# Associate GitHub account with Slack user
+##########################################
 @pytest.mark.unit
 def test_connect_command_new_user(session):
     data = {"user_id": "new_user"}
@@ -251,6 +256,9 @@ def test_reconnect_command_existing_user(add_user):
     )
 
 
+########################
+# Miscellaneous Commands
+########################
 @pytest.mark.unit
 def test_command_help():
     result = display_help_text()


### PR DESCRIPTION
Closes #143.

The `EventEmitter` pattern allows us to separate concerns into simple functions that we can unit test thoroughly. In order to enable us to move quickly, I configured the `slack-slash-command` endpoint to leverage an `EventEmitter` to dispatch functions.

### Specific Changes

- Create test fixture to generate request as sent to webhook for more accurate testing
- Refactored single Slack resource module into separate modules
- Add command to delete GitHub association with Slack account (`/busybeaver disconnect`)
- Added documentation on how contributors can create a new slash command

### Resources

- [Slack Docs: Slash Commands](https://api.slack.com/slash-commands)