### PR TITLE
Sync event table

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@ attach: ## attach to process for debugging purposes
 migration: ## create migration m="message"
 	docker-compose exec app flask db migrate -m "$(m)"
 
+migration-empty: ## create empty migration m="message
+	docker-compose exec app flask db revision -m "$(m)"
+
 migrate-up: ## run all migration
 	docker-compose exec app flask db upgrade
 

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -12,3 +12,4 @@
     dest: "{{ app_dir }}"
 
 # TODO: create and start systemd service
+# TODO: install postgres on server

--- a/busy_beaver/adapters/meetup.py
+++ b/busy_beaver/adapters/meetup.py
@@ -10,7 +10,8 @@ class EventDetails(NamedTuple):
     name: str
     url: str
     venue: str
-    dt: int  # utc epoch
+    start_epoch: int  # utc epoch
+    end_epoch: int
 
     def create_event_record(self) -> Event:
         return Event(
@@ -18,7 +19,8 @@ class EventDetails(NamedTuple):
             name=self.name,
             url=self.url,
             venue=self.venue,
-            utc_epoch=self.dt,
+            start_epoch=self.start_epoch,
+            end_epoch=self.end_epoch,
         )
 
     @classmethod
@@ -30,7 +32,8 @@ class EventDetails(NamedTuple):
             name=model.name,
             url=model.url,
             venue=model.venue,
-            dt=model.utc_epoch,
+            start_epoch=model.start_epoch,
+            end_epoch=model.end_epoch,
         )
 
 
@@ -52,13 +55,15 @@ class MeetupAdapter:
             else:
                 venue_name = "TBD"
 
+            start_epoch = int(event["time"] / 1000)
             upcoming_events.append(
                 EventDetails(
                     id=event["id"],
                     name=event["name"],
                     url=event["event_url"],
                     venue=venue_name,
-                    dt=int(event["time"] / 1000),
+                    start_epoch=start_epoch,
+                    end_epoch=start_epoch + int(event["duration"]),
                 )
             )
 

--- a/busy_beaver/adapters/meetup.py
+++ b/busy_beaver/adapters/meetup.py
@@ -1,4 +1,4 @@
-from typing import List, NamedTuple
+from typing import Dict, List, NamedTuple
 from meetup.api import Client as MeetupClient
 
 from busy_beaver.exceptions import NoMeetupEventsFound
@@ -13,16 +13,6 @@ class EventDetails(NamedTuple):
     start_epoch: int  # utc epoch
     end_epoch: int
 
-    def create_event_record(self) -> Event:
-        return Event(
-            remote_id=self.id,
-            name=self.name,
-            url=self.url,
-            venue=self.venue,
-            start_epoch=self.start_epoch,
-            end_epoch=self.end_epoch,
-        )
-
     @classmethod
     def from_event_model(cls, model):
         if not isinstance(model, Event):
@@ -35,6 +25,20 @@ class EventDetails(NamedTuple):
             start_epoch=model.start_epoch,
             end_epoch=model.end_epoch,
         )
+
+    def create_event_record_dict(self) -> Dict[str, str]:
+        return {
+            "remote_id": self.id,
+            "name": self.name,
+            "url": self.url,
+            "venue": self.venue,
+            "start_epoch": self.start_epoch,
+            "end_epoch": self.end_epoch,
+        }
+
+    def create_event_record(self) -> Event:
+        event_params = self.create_event_record_dict()
+        return Event(**event_params)
 
 
 class MeetupAdapter:

--- a/busy_beaver/apps/README.md
+++ b/busy_beaver/apps/README.md
@@ -7,7 +7,11 @@ Each package inside of this folder contains Busy Beaver features.
 ### Events Database
 
 This feature polls Meetup once a day and
-adds new events to the application's database.
+adds syncs database with fetched events.
+
+- new event get created
+- removed events get deleted
+- existing events get updated
 
 ### GitHub Summary
 

--- a/busy_beaver/apps/events_database/sync_database.py
+++ b/busy_beaver/apps/events_database/sync_database.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, List, NamedTuple
+from typing import List, NamedTuple
 
 from busy_beaver.adapters.meetup import EventDetails
 from busy_beaver.extensions import db
@@ -8,7 +8,7 @@ from busy_beaver.models import Event
 logger = logging.getLogger(__name__)
 
 
-class TransactionType(NamedTuple):
+class PendingTransactions(NamedTuple):
     create: list
     update: list
     delete: list
@@ -23,12 +23,8 @@ class SyncDatabaseWithEvents:
     def __init__(
         self, fetched_events: List[EventDetails], database_events: List[Event]
     ):
-        self.fetched_events_map: Dict[str, EventDetails] = {
-            event.id: event for event in fetched_events
-        }
-        self.database_events_map: Dict[str, Event] = {
-            event.remote_id: event for event in database_events
-        }
+        self.fetched_events_map = {event.id: event for event in fetched_events}
+        self.database_events_map = {event.remote_id: event for event in database_events}
         self.transactions = classify_transaction_type(
             fetched_ids=self.fetched_events_map.keys(),
             database_ids=self.database_events_map.keys(),
@@ -90,4 +86,4 @@ def classify_transaction_type(fetched_ids: list, database_ids: list):
     delete_ids = list(database_event_ids - fetched_event_ids)
     update_ids = list(database_event_ids.intersection(fetched_event_ids))
 
-    return TransactionType(create=add_ids, update=update_ids, delete=delete_ids)
+    return PendingTransactions(create=add_ids, update=update_ids, delete=delete_ids)

--- a/busy_beaver/apps/events_database/sync_database.py
+++ b/busy_beaver/apps/events_database/sync_database.py
@@ -1,0 +1,93 @@
+import logging
+from typing import Dict, List, NamedTuple
+
+from busy_beaver.adapters.meetup import EventDetails
+from busy_beaver.extensions import db
+from busy_beaver.models import Event
+
+logger = logging.getLogger(__name__)
+
+
+class TransactionType(NamedTuple):
+    create: list
+    update: list
+    delete: list
+
+
+class UpdateRecord(NamedTuple):
+    current: Event
+    new: EventDetails
+
+
+class SyncDatabaseWithEvents:
+    def __init__(
+        self, fetched_events: List[EventDetails], database_events: List[Event]
+    ):
+        self.fetched_events_map: Dict[str, EventDetails] = {
+            event.id: event for event in fetched_events
+        }
+        self.database_events_map: Dict[str, Event] = {
+            event.remote_id: event for event in database_events
+        }
+        self.transactions = classify_transaction_type(
+            fetched_ids=self.fetched_events_map.keys(),
+            database_ids=self.database_events_map.keys(),
+        )
+
+    def perform(self):
+        self._add_events_to_database()
+        self._delete_events_from_database()
+        self._update_events_in_database()
+
+    def _add_events_to_database(self):
+        events = [self.fetched_events_map[id_] for id_ in self.transactions.create]
+
+        num_created = 0
+        for event in events:
+            record = event.create_event_record()
+            db.session.add(record)
+            num_created += 1
+        else:
+            db.session.commit()
+            logger.info("{0} events saved to the database".format(num_created))
+
+    def _delete_events_from_database(self):
+        events = [self.database_events_map[id_] for id_ in self.transactions.delete]
+
+        num_deleted = 0
+        for event in events:
+            db.session.delete(event)
+            num_deleted += 1
+        else:
+            db.session.commit()
+            logger.info("{0} events deleted from the database".format(num_deleted))
+
+    def _update_events_in_database(self):
+        events = [
+            UpdateRecord(self.database_events_map[id_], self.fetched_events_map[id_])
+            for id_ in self.transactions.update
+        ]
+
+        num_updated = 0
+        for event_details in events:
+            event_in_db = event_details.current
+            fetched_event = event_details.new.create_event_record_dict()
+
+            event_in_db.patch(fetched_event)
+            db.session.add(event_in_db)
+            num_updated += 1
+        else:
+            db.session.commit()
+            logger.info("{0} events updated in the database".format(num_updated))
+
+
+# TODO: look into testing with hypothesis
+def classify_transaction_type(fetched_ids: list, database_ids: list):
+    fetched_event_ids = set(fetched_ids)
+    database_event_ids = set(database_ids)
+
+    add_ids = list(fetched_event_ids - database_event_ids)
+    delete_ids = list(database_event_ids - fetched_event_ids)
+    update_ids = list(database_event_ids.intersection(fetched_event_ids))
+
+    return TransactionType(create=add_ids, update=update_ids, delete=delete_ids)

--- a/busy_beaver/apps/events_database/sync_database.py
+++ b/busy_beaver/apps/events_database/sync_database.py
@@ -19,7 +19,7 @@ class UpdateRecord(NamedTuple):
     new: EventDetails
 
 
-class SyncDatabaseWithEvents:
+class SyncEventDatabase:
     def __init__(
         self, fetched_events: List[EventDetails], database_events: List[Event]
     ):

--- a/busy_beaver/apps/events_database/task.py
+++ b/busy_beaver/apps/events_database/task.py
@@ -19,7 +19,7 @@ from busy_beaver.models import ApiUser, SyncEventDatabaseTask, Event
 logger = logging.getLogger(__name__)
 
 
-def start_add_events_to_database_task(task_owner: ApiUser):
+def start_sync_events_database_task(task_owner: ApiUser):
     logger.info("[Busy Beaver] Kick off fetch meetup events task")
 
     group_name = MEETUP_GROUP_NAME

--- a/busy_beaver/apps/events_database/task.py
+++ b/busy_beaver/apps/events_database/task.py
@@ -10,11 +10,11 @@ the set of future events in the database:
 import logging
 import time
 
-from .sync_database import SyncDatabaseWithEvents
+from .sync_database import SyncEventDatabase
 from busy_beaver import meetup
 from busy_beaver.config import MEETUP_GROUP_NAME
 from busy_beaver.extensions import db, rq
-from busy_beaver.models import ApiUser, AddEventsToDatabaseTask, Event
+from busy_beaver.models import ApiUser, SyncEventDatabaseTask, Event
 
 logger = logging.getLogger(__name__)
 
@@ -25,7 +25,7 @@ def start_add_events_to_database_task(task_owner: ApiUser):
     group_name = MEETUP_GROUP_NAME
     job = sync_database_with_fetched_events.queue(group_name)
 
-    task = AddEventsToDatabaseTask(
+    task = SyncEventDatabaseTask(
         job_id=job.id,
         name="Poll Meetup",
         description="Poll Meetup for events",
@@ -43,5 +43,5 @@ def sync_database_with_fetched_events(group_name):
     current_epoch_time = int(time.time())
     database_events = Event.query.filter(Event.start_epoch > current_epoch_time).all()
 
-    sync_database = SyncDatabaseWithEvents(fetched_events, database_events)
+    sync_database = SyncEventDatabase(fetched_events, database_events)
     sync_database.perform()

--- a/busy_beaver/apps/events_database/task.py
+++ b/busy_beaver/apps/events_database/task.py
@@ -1,26 +1,34 @@
+"""Update Events Database task
+
+This task pulls a set of events from Meetup and performs the following action against
+the set of future events in the database:
+    - if event is new => create
+    - if event is in the database, but not in the fetched events => delete
+    - if event is in the database => update
+
+"""
 import logging
 import time
-from typing import List
 
+from .myclass import SyncDatabaseWithEvents
 from busy_beaver import meetup
 from busy_beaver.config import MEETUP_GROUP_NAME
 from busy_beaver.extensions import db, rq
-from busy_beaver.models import ApiUser, NewEventsToDatabaseTask
-from busy_beaver.models import Event
+from busy_beaver.models import ApiUser, AddEventsToDatabaseTask, Event
 
 logger = logging.getLogger(__name__)
 
 
 def start_add_events_to_database_task(task_owner: ApiUser):
-    logger.info("[Busy Beaver] Kick off fetch new meetup events task")
+    logger.info("[Busy Beaver] Kick off fetch meetup events task")
 
     group_name = MEETUP_GROUP_NAME
-    job = add_events_to_database.queue(group_name)
+    job = sync_database_with_fetched_events.queue(group_name)
 
-    task = NewEventsToDatabaseTask(
+    task = AddEventsToDatabaseTask(
         job_id=job.id,
         name="Poll Meetup",
-        description="Poll Meetup for new events",
+        description="Poll Meetup for events",
         user=task_owner,
         data={"group_name": group_name},
     )
@@ -29,33 +37,11 @@ def start_add_events_to_database_task(task_owner: ApiUser):
 
 
 @rq.job
-def add_events_to_database(group_name):
+def sync_database_with_fetched_events(group_name):
     fetched_events = meetup.get_events(group_name, count=20)
-    fetched_remote_id = [event.id for event in fetched_events]
 
-    remote_ids_in_database = _fetch_future_event_ids_from_database()
-    ids_to_add = set(fetched_remote_id) - set(remote_ids_in_database)
-    events_to_add: List[Event] = [
-        event for event in fetched_events if event.id in ids_to_add
-    ]
-
-    _insert_events_into_database(events_to_add)
-
-
-def _fetch_future_event_ids_from_database():
     current_epoch_time = int(time.time())
-    upcoming_events_in_db = Event.query.filter(
-        Event.start_epoch > current_epoch_time
-    ).all()
-    return [event.remote_id for event in upcoming_events_in_db]
+    database_events = Event.query.filter(Event.start_epoch > current_epoch_time).all()
 
-
-def _insert_events_into_database(events):
-    num_records_created = 0
-    for event in events:
-        record = event.create_event_record()
-        db.session.add(record)
-        num_records_created += 1
-    else:
-        db.session.commit()
-        logger.info("{0} events saved to the database".format(num_records_created))
+    sync_database = SyncDatabaseWithEvents(fetched_events, database_events)
+    sync_database.perform()

--- a/busy_beaver/apps/events_database/task.py
+++ b/busy_beaver/apps/events_database/task.py
@@ -5,19 +5,19 @@ from typing import List
 from busy_beaver import meetup
 from busy_beaver.config import MEETUP_GROUP_NAME
 from busy_beaver.extensions import db, rq
-from busy_beaver.models import ApiUser, AddNewEventsToDatabaseTask
+from busy_beaver.models import ApiUser, NewEventsToDatabaseTask
 from busy_beaver.models import Event
 
 logger = logging.getLogger(__name__)
 
 
-def start_add_new_events_to_database_task(task_owner: ApiUser):
+def start_add_events_to_database_task(task_owner: ApiUser):
     logger.info("[Busy Beaver] Kick off fetch new meetup events task")
 
     group_name = MEETUP_GROUP_NAME
-    job = add_new_events_to_database.queue(group_name)
+    job = add_events_to_database.queue(group_name)
 
-    task = AddNewEventsToDatabaseTask(
+    task = NewEventsToDatabaseTask(
         job_id=job.id,
         name="Poll Meetup",
         description="Poll Meetup for new events",
@@ -29,7 +29,7 @@ def start_add_new_events_to_database_task(task_owner: ApiUser):
 
 
 @rq.job
-def add_new_events_to_database(group_name):
+def add_events_to_database(group_name):
     fetched_events = meetup.get_events(group_name, count=20)
     fetched_remote_id = [event.id for event in fetched_events]
 

--- a/busy_beaver/apps/events_database/task.py
+++ b/busy_beaver/apps/events_database/task.py
@@ -45,7 +45,7 @@ def add_new_events_to_database(group_name):
 def _fetch_future_event_ids_from_database():
     current_epoch_time = int(time.time())
     upcoming_events_in_db = Event.query.filter(
-        Event.utc_epoch > current_epoch_time
+        Event.start_epoch > current_epoch_time
     ).all()
     return [event.remote_id for event in upcoming_events_in_db]
 

--- a/busy_beaver/apps/events_database/task.py
+++ b/busy_beaver/apps/events_database/task.py
@@ -19,7 +19,7 @@ from busy_beaver.models import ApiUser, SyncEventDatabaseTask, Event
 logger = logging.getLogger(__name__)
 
 
-def start_sync_events_database_task(task_owner: ApiUser):
+def start_sync_event_database_task(task_owner: ApiUser):
     logger.info("[Busy Beaver] Kick off fetch meetup events task")
 
     group_name = MEETUP_GROUP_NAME

--- a/busy_beaver/apps/events_database/task.py
+++ b/busy_beaver/apps/events_database/task.py
@@ -10,7 +10,7 @@ the set of future events in the database:
 import logging
 import time
 
-from .myclass import SyncDatabaseWithEvents
+from .sync_database import SyncDatabaseWithEvents
 from busy_beaver import meetup
 from busy_beaver.config import MEETUP_GROUP_NAME
 from busy_beaver.extensions import db, rq

--- a/busy_beaver/apps/events_database/task.py
+++ b/busy_beaver/apps/events_database/task.py
@@ -5,8 +5,8 @@ the set of future events in the database:
     - if event is new => create
     - if event is in the database, but not in the fetched events => delete
     - if event is in the database => update
-
 """
+
 import logging
 import time
 

--- a/busy_beaver/apps/upcoming_events/cards.py
+++ b/busy_beaver/apps/upcoming_events/cards.py
@@ -35,7 +35,7 @@ class UpcomingEvent:
     def __init__(self, event: EventDetails):
         event_information_string = (
             f"*<{event.url}|{event.name}>*\n"
-            f"<!date^{event.dt}^{{date_long}} @ {{time}}|no date>"
+            f"<!date^{event.start_epoch}^{{date_long}} @ {{time}}|no date>"
         )
         event_location_string = f":round_pushpin: Location: {event.venue}"
         self.output = [

--- a/busy_beaver/apps/upcoming_events/cards.py
+++ b/busy_beaver/apps/upcoming_events/cards.py
@@ -5,14 +5,11 @@ from busy_beaver.toolbox.slack_block_kit import Context, Divider, Image, Section
 
 
 class UpcomingEventList:
-    def __init__(self, title, events: List[EventDetails]):
+    def __init__(self, events: List[EventDetails], group_name: str, image_url: str):
         # TODO when we go multitenant, the image box will need to change
         output = [
-            Image(
-                image_url="https://www.chipy.org/static/img/chipmunk.1927e65c68a7.png",
-                alt_text="ChiPy",
-            ),
-            Section(title),
+            Image(image_url=image_url, alt_text=group_name),
+            Section("*Upcoming Events*"),
             Divider(),
         ]
 

--- a/busy_beaver/apps/upcoming_events/workflow.py
+++ b/busy_beaver/apps/upcoming_events/workflow.py
@@ -8,7 +8,9 @@ from busy_beaver.models import Event
 
 def generate_upcoming_events_message(group_name: str, count: int):
     events = _fetch_future_events_from_database(group_name, count)
-    return UpcomingEventList("*Upcoming Events*", events).to_dict()
+    # TODO: for multi-tenant we will need to use group_name to look up url
+    image_url = "https://www.chipy.org/static/img/chipmunk.1927e65c68a7.png"
+    return UpcomingEventList(events, group_name, image_url).to_dict()
 
 
 def generate_next_event_message(group_name: str):
@@ -17,8 +19,7 @@ def generate_next_event_message(group_name: str):
 
 
 def post_upcoming_events_message_to_slack(channel: str, group_name: str, count: int):
-    events = _fetch_future_events_from_database(group_name, count)
-    blocks = UpcomingEventList("*Upcoming Events*", events).to_dict()
+    blocks = generate_upcoming_events_message(group_name, count)
     slack.post_message(blocks=blocks, channel=channel)
 
 

--- a/busy_beaver/apps/upcoming_events/workflow.py
+++ b/busy_beaver/apps/upcoming_events/workflow.py
@@ -27,8 +27,8 @@ def _fetch_future_events_from_database(group_name, count):
     # TODO: for multi-tenant we will need use group_name in query
     current_epoch_time = int(time.time())
     upcoming_events_in_db = (
-        Event.query.filter(Event.utc_epoch > current_epoch_time)
-        .order_by(Event.utc_epoch)
+        Event.query.filter(Event.start_epoch > current_epoch_time)
+        .order_by(Event.start_epoch)
         .limit(count)
     )
     return [EventDetails.from_event_model(model) for model in upcoming_events_in_db]
@@ -42,6 +42,6 @@ def _next_event_attachment(event: EventDetails) -> dict:
         "title": event.name,
         "title_link": event.url,
         "fallback": f"{event.name}: {event.url}",
-        "text": f"*<!date^{event.dt}^{{time}} {{date_long}}|no date>* at {event.venue}",
+        "text": f"*<!date^{event.start_epoch}^{{time}} {{date_long}}|no date>* at {event.venue}",
         "color": "#008952",
     }

--- a/busy_beaver/blueprints/poller/__init__.py
+++ b/busy_beaver/blueprints/poller/__init__.py
@@ -26,8 +26,9 @@ poller_bp.add_url_rule(
 )
 
 view = AddEventPollingResource.as_view("meetup_poller")
-# TODO make this /add-events
-poller_bp.add_url_rule("/events", view_func=admin_role_required(view), methods=["POST"])
+poller_bp.add_url_rule(
+    "/sync-event-database", view_func=admin_role_required(view), methods=["POST"]
+)
 
 view = YouTubePollingResource.as_view("youtube_poller")
 poller_bp.add_url_rule(

--- a/busy_beaver/blueprints/poller/__init__.py
+++ b/busy_beaver/blueprints/poller/__init__.py
@@ -3,7 +3,7 @@ from flask import blueprints
 from .github_summary import PublishGitHubSummaryResource
 from .retweeter import TwitterPollingResource
 from .upcoming_events import PublishUpcomingEventsResource
-from .update_events import AddNewEventPollingResource
+from .update_events import AddEventPollingResource
 from .youtube_post import YouTubePollingResource
 from busy_beaver.blueprints.toolbox import authentication_required
 
@@ -25,7 +25,8 @@ poller_bp.add_url_rule(
     "/upcoming-events", view_func=admin_role_required(view), methods=["POST"]
 )
 
-view = AddNewEventPollingResource.as_view("meetup_poller")
+view = AddEventPollingResource.as_view("meetup_poller")
+# TODO make this /add-events
 poller_bp.add_url_rule("/events", view_func=admin_role_required(view), methods=["POST"])
 
 view = YouTubePollingResource.as_view("youtube_poller")

--- a/busy_beaver/blueprints/poller/update_events.py
+++ b/busy_beaver/blueprints/poller/update_events.py
@@ -3,7 +3,7 @@ import logging
 from flask import request
 from flask.views import MethodView
 
-from busy_beaver.apps.events_database.task import start_add_events_to_database_task
+from busy_beaver.apps.events_database.task import start_sync_events_database_task
 from busy_beaver.toolbox import make_response
 
 logger = logging.getLogger(__name__)
@@ -19,7 +19,7 @@ class AddEventPollingResource(MethodView):
             extra={"user": user.username},
         )
 
-        start_add_events_to_database_task(user)
+        start_sync_events_database_task(user)
 
         logger.info("[Busy Beaver] Add New Events Poll -- kicked-off")
         return make_response(200, json={"run": "complete"})

--- a/busy_beaver/blueprints/poller/update_events.py
+++ b/busy_beaver/blueprints/poller/update_events.py
@@ -3,7 +3,7 @@ import logging
 from flask import request
 from flask.views import MethodView
 
-from busy_beaver.apps.events_database.task import start_sync_events_database_task
+from busy_beaver.apps.events_database.task import start_sync_event_database_task
 from busy_beaver.toolbox import make_response
 
 logger = logging.getLogger(__name__)
@@ -19,7 +19,7 @@ class AddEventPollingResource(MethodView):
             extra={"user": user.username},
         )
 
-        start_sync_events_database_task(user)
+        start_sync_event_database_task(user)
 
         logger.info("[Busy Beaver] Add New Events Poll -- kicked-off")
         return make_response(200, json={"run": "complete"})

--- a/busy_beaver/blueprints/poller/update_events.py
+++ b/busy_beaver/blueprints/poller/update_events.py
@@ -3,14 +3,14 @@ import logging
 from flask import request
 from flask.views import MethodView
 
-from busy_beaver.apps.events_database.task import start_add_new_events_to_database_task
+from busy_beaver.apps.events_database.task import start_add_events_to_database_task
 from busy_beaver.toolbox import make_response
 
 logger = logging.getLogger(__name__)
 
 
-class AddNewEventPollingResource(MethodView):
-    """Endpoint to trigger polling of Meetup for new events to add to database"""
+class AddEventPollingResource(MethodView):
+    """Endpoint to trigger polling of Meetup for events to add to database"""
 
     def post(self):
         user = request._internal["user"]
@@ -19,7 +19,7 @@ class AddNewEventPollingResource(MethodView):
             extra={"user": user.username},
         )
 
-        start_add_new_events_to_database_task(user)
+        start_add_events_to_database_task(user)
 
         logger.info("[Busy Beaver] Add New Events Poll -- kicked-off")
         return make_response(200, json={"run": "complete"})

--- a/busy_beaver/factories/event.py
+++ b/busy_beaver/factories/event.py
@@ -1,8 +1,5 @@
 from datetime import datetime, timedelta
-import uuid
-
 import factory
-
 from busy_beaver.models import Event
 
 
@@ -10,7 +7,7 @@ class EventFactory(factory.Factory):
     class Meta:
         model = Event
 
-    remote_id = str(uuid.uuid4())
+    remote_id = factory.Faker("uuid4")
     name = "ChiPy"
     url = "http://meetup.com/_ChiPy_/event/blah"
     start_epoch = int((datetime.now() + timedelta(days=1)).timestamp())

--- a/busy_beaver/factories/event.py
+++ b/busy_beaver/factories/event.py
@@ -13,5 +13,6 @@ class EventFactory(factory.Factory):
     remote_id = str(uuid.uuid4())
     name = "ChiPy"
     url = "http://meetup.com/_ChiPy_/event/blah"
-    utc_epoch = int((datetime.now() + timedelta(days=1)).timestamp())
+    start_epoch = int((datetime.now() + timedelta(days=1)).timestamp())
+    end_epoch = start_epoch + 60 * 60 * 2
     venue = "Numerator"

--- a/busy_beaver/factories/event_details.py
+++ b/busy_beaver/factories/event_details.py
@@ -1,7 +1,4 @@
 from datetime import datetime, timedelta
-
-import uuid
-
 import factory
 from busy_beaver.adapters.meetup import EventDetails
 
@@ -10,7 +7,7 @@ class EventDetailsFactory(factory.Factory):
     class Meta:
         model = EventDetails
 
-    id = str(uuid.uuid4())
+    id = factory.Faker("uuid4")
     name = "ChiPy"
     url = "http://meetup.com/_ChiPy_/event/blah"
     start_epoch = int((datetime.now() + timedelta(days=1)).timestamp())

--- a/busy_beaver/factories/event_details.py
+++ b/busy_beaver/factories/event_details.py
@@ -13,5 +13,6 @@ class EventDetailsFactory(factory.Factory):
     id = str(uuid.uuid4())
     name = "ChiPy"
     url = "http://meetup.com/_ChiPy_/event/blah"
-    dt = int((datetime.now() + timedelta(days=1)).timestamp())
+    start_epoch = int((datetime.now() + timedelta(days=1)).timestamp())
+    end_epoch = start_epoch + 60 * 60 * 2
     venue = "Numerator"

--- a/busy_beaver/models/__init__.py
+++ b/busy_beaver/models/__init__.py
@@ -8,7 +8,7 @@ from .event import Event  # noqa
 from .key_value import KeyValueStore  # noqa
 from .task import (  # noqa
     Task,
-    AddNewEventsToDatabaseTask,
+    NewEventsToDatabaseTask,
     PostGitHubSummaryTask,
     PostTweetTask,
 )

--- a/busy_beaver/models/__init__.py
+++ b/busy_beaver/models/__init__.py
@@ -8,7 +8,7 @@ from .event import Event  # noqa
 from .key_value import KeyValueStore  # noqa
 from .task import (  # noqa
     Task,
-    AddEventsToDatabaseTask,
+    SyncEventDatabaseTask,
     PostGitHubSummaryTask,
     PostTweetTask,
 )

--- a/busy_beaver/models/__init__.py
+++ b/busy_beaver/models/__init__.py
@@ -8,7 +8,7 @@ from .event import Event  # noqa
 from .key_value import KeyValueStore  # noqa
 from .task import (  # noqa
     Task,
-    NewEventsToDatabaseTask,
+    AddEventsToDatabaseTask,
     PostGitHubSummaryTask,
     PostTweetTask,
 )

--- a/busy_beaver/models/event.py
+++ b/busy_beaver/models/event.py
@@ -15,4 +15,5 @@ class Event(BaseModel):
     name = db.Column(db.String(255), nullable=False)
     url = db.Column(db.String(500), nullable=False)
     venue = db.Column(db.String(255), nullable=False)
-    utc_epoch = db.Column(db.Integer, nullable=False)
+    start_epoch = db.Column(db.Integer, nullable=False)
+    end_epoch = db.Column(db.Integer, nullable=False)

--- a/busy_beaver/models/task.py
+++ b/busy_beaver/models/task.py
@@ -70,9 +70,9 @@ class PostTweetTask(Task):
         return f"<PostTweetTask: {self.data}>"
 
 
-class AddNewEventsToDatabaseTask(Task):
+class NewEventsToDatabaseTask(Task):
 
-    __tablename__ = "fetch_new_events_task"
+    __tablename__ = "fetch_events_task"
 
     # Attributes
     id = db.Column(db.Integer, db.ForeignKey("task.id"), primary_key=True)
@@ -81,4 +81,4 @@ class AddNewEventsToDatabaseTask(Task):
     __mapper_args__ = {"polymorphic_identity": "fetch_new_events"}
 
     def __repr__(self):  # pragma: no cover
-        return f"<AddNewEventsToDatabaseTask: {self.data}>"
+        return f"<NewEventsToDatabaseTask: {self.data}>"

--- a/busy_beaver/models/task.py
+++ b/busy_beaver/models/task.py
@@ -72,13 +72,13 @@ class PostTweetTask(Task):
 
 class SyncEventDatabaseTask(Task):
 
-    __tablename__ = "fetch_new_events_task"
+    __tablename__ = "sync_event_database_task"
 
     # Attributes
     id = db.Column(db.Integer, db.ForeignKey("task.id"), primary_key=True)
     data = db.Column("data", db.JSON)
 
-    __mapper_args__ = {"polymorphic_identity": "fetch_new_events"}
+    __mapper_args__ = {"polymorphic_identity": "sync_event_database"}
 
     def __repr__(self):  # pragma: no cover
         return f"<NewEventsToDatabaseTask: {self.data}>"

--- a/busy_beaver/models/task.py
+++ b/busy_beaver/models/task.py
@@ -70,9 +70,9 @@ class PostTweetTask(Task):
         return f"<PostTweetTask: {self.data}>"
 
 
-class AddEventsToDatabaseTask(Task):
+class SyncEventDatabaseTask(Task):
 
-    __tablename__ = "fetch_events_task"
+    __tablename__ = "fetch_new_events_task"
 
     # Attributes
     id = db.Column(db.Integer, db.ForeignKey("task.id"), primary_key=True)

--- a/busy_beaver/models/task.py
+++ b/busy_beaver/models/task.py
@@ -70,7 +70,7 @@ class PostTweetTask(Task):
         return f"<PostTweetTask: {self.data}>"
 
 
-class NewEventsToDatabaseTask(Task):
+class AddEventsToDatabaseTask(Task):
 
     __tablename__ = "fetch_events_task"
 

--- a/busy_beaver/models/task.py
+++ b/busy_beaver/models/task.py
@@ -81,4 +81,4 @@ class SyncEventDatabaseTask(Task):
     __mapper_args__ = {"polymorphic_identity": "sync_event_database"}
 
     def __repr__(self):  # pragma: no cover
-        return f"<NewEventsToDatabaseTask: {self.data}>"
+        return f"<SyncEventDatabaseTask: {self.data}>"

--- a/migrations/versions/20190526_22-47-39__change_column_name_and_add_end_epoch_in_.py
+++ b/migrations/versions/20190526_22-47-39__change_column_name_and_add_end_epoch_in_.py
@@ -17,13 +17,23 @@ depends_on = None
 
 
 def upgrade():
+    # Step 1: Schema table
+    # Change column name (to start_epoch) and add end_epoch column
     op.alter_column(
         "event", "utc_epoch", new_column_name="start_epoch", server_default=None
     )
     op.add_column("event", sa.Column("end_epoch", sa.Integer(), nullable=True))
 
-    # copy start_epoch to end_epoch
-    # alter column to nullable = False
+    # Step 2: Data Migration
+    # Set end_epoch col to start_epoch col
+    engine = op.get_bind()
+    meta = sa.MetaData(bind=engine)
+    event = sa.Table("event", meta, autoload=True)
+    stmt = event.update().values(end_epoch=event.c.start_epoch)
+    engine.execute(stmt)
+
+    # Step 3: Schema table
+    # end_epoch column can't be empty
     op.alter_column("event", "end_epoch", nullable=False)
 
 

--- a/migrations/versions/20190526_22-47-39__change_column_name_and_add_end_epoch_in_.py
+++ b/migrations/versions/20190526_22-47-39__change_column_name_and_add_end_epoch_in_.py
@@ -36,15 +36,9 @@ def upgrade():
     # end_epoch column can't be empty
     op.alter_column("event", "end_epoch", nullable=False)
 
-    # Step 4: Schema migration
-    # rename table
-    op.rename_table("fetch_new_events_task", "fetch_events_task")
-
 
 def downgrade():
     op.alter_column(
         "event", "start_epoch", new_column_name="utc_epoch", server_default=None
     )
     op.drop_column("event", "end_epoch")
-
-    op.rename_table("fetch_events_task", "fetch_new_events_task")

--- a/migrations/versions/20190526_22-47-39__change_column_name_and_add_end_epoch_in_.py
+++ b/migrations/versions/20190526_22-47-39__change_column_name_and_add_end_epoch_in_.py
@@ -1,0 +1,34 @@
+"""change column name and add end_epoch in event table
+
+Revision ID: ad8d0445e832
+Revises: 958548ca6d07
+Create Date: 2019-05-26 22:47:39.821526
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "ad8d0445e832"
+down_revision = "958548ca6d07"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column(
+        "event", "utc_epoch", new_column_name="start_epoch", server_default=None
+    )
+    op.add_column("event", sa.Column("end_epoch", sa.Integer(), nullable=True))
+
+    # copy start_epoch to end_epoch
+    # alter column to nullable = False
+    op.alter_column("event", "end_epoch", nullable=False)
+
+
+def downgrade():
+    op.alter_column(
+        "event", "start_epoch", new_column_name="utc_epoch", server_default=None
+    )
+    op.drop_column("event", "end_epoch")

--- a/migrations/versions/20190526_22-47-39__change_column_name_and_add_end_epoch_in_.py
+++ b/migrations/versions/20190526_22-47-39__change_column_name_and_add_end_epoch_in_.py
@@ -17,14 +17,14 @@ depends_on = None
 
 
 def upgrade():
-    # Step 1: Schema table
+    # Step 1: Schema migration
     # Change column name (to start_epoch) and add end_epoch column
     op.alter_column(
         "event", "utc_epoch", new_column_name="start_epoch", server_default=None
     )
     op.add_column("event", sa.Column("end_epoch", sa.Integer(), nullable=True))
 
-    # Step 2: Data Migration
+    # Step 2: Data migration
     # Set end_epoch col to start_epoch col
     engine = op.get_bind()
     meta = sa.MetaData(bind=engine)
@@ -32,9 +32,13 @@ def upgrade():
     stmt = event.update().values(end_epoch=event.c.start_epoch)
     engine.execute(stmt)
 
-    # Step 3: Schema table
+    # Step 3: Schema migration
     # end_epoch column can't be empty
     op.alter_column("event", "end_epoch", nullable=False)
+
+    # Step 4: Schema migration
+    # rename table
+    op.rename_table("fetch_new_events_task", "fetch_events_task")
 
 
 def downgrade():
@@ -42,3 +46,5 @@ def downgrade():
         "event", "start_epoch", new_column_name="utc_epoch", server_default=None
     )
     op.drop_column("event", "end_epoch")
+
+    op.rename_table("fetch_events_task", "fetch_new_events_task")

--- a/migrations/versions/20190609_20-09-41__rename_sync_event_task_table_and_update_.py
+++ b/migrations/versions/20190609_20-09-41__rename_sync_event_task_table_and_update_.py
@@ -1,0 +1,48 @@
+"""rename sync event task table and update values
+
+Revision ID: 383bbb33f257
+Revises: ad8d0445e832
+Create Date: 2019-06-09 20:09:41.764048
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "383bbb33f257"
+down_revision = "ad8d0445e832"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Step 1: Schema migration
+    # rename table
+    op.rename_table("fetch_new_events_task", "sync_event_database_task")
+
+    # Step 2: Data migration
+    # Change task type to new sync_task_name
+    engine = op.get_bind()
+    meta = sa.MetaData(bind=engine)
+    task = sa.Table("task", meta, autoload=True)
+    stmt = (
+        task.update()
+        .where(task.c.type == "fetch_new_events")
+        .values(type="sync_event_database")
+    )
+    engine.execute(stmt)
+
+
+def downgrade():
+    op.rename_table("sync_event_database_task", "fetch_new_events_task")
+
+    engine = op.get_bind()
+    meta = sa.MetaData(bind=engine)
+    task = sa.Table("task", meta, autoload=True)
+    stmt = (
+        task.update()
+        .where(task.c.type == "sync_event_database")
+        .values(type="fetch_new_events")
+    )
+    engine.execute(stmt)

--- a/scripts/prod/events_poller.sh
+++ b/scripts/prod/events_poller.sh
@@ -2,7 +2,7 @@
 
 source $HOME/.bash_profile
 
-curl https://busybeaver.sivji.com/poll/events \
+curl https://busybeaver.sivji.com/poll/sync-event-database \
     -X POST \
     -H "Content-Type: application/json" \
     -H "Authorization: token ${BUSY_BEAVER_API_TOKEN}"

--- a/tests/adapters/meetup_test.py
+++ b/tests/adapters/meetup_test.py
@@ -64,6 +64,7 @@ def test_venue_not_specified_returns_tbd(patched_meetup_client):
                 "name": "ChiPy",
                 "event_url": "http://meetup.com/_ChiPy_/event/blah",
                 "time": 1_557_959_400_000,
+                "duration": 1_557_959_400_000 + 60 * 60 * 2,
             }
         ]
     )
@@ -98,7 +99,7 @@ def test_event_details_creating_event_objects():
 
     # Assert
     assert event.name == created_event.name
-    assert event.utc_epoch == created_event.utc_epoch
+    assert event.start_epoch == created_event.start_epoch
     assert event.venue == created_event.venue
 
 

--- a/tests/apps/events_database/sync_database_test.py
+++ b/tests/apps/events_database/sync_database_test.py
@@ -1,0 +1,14 @@
+import pytest
+from busy_beaver.apps.events_database.sync_database import classify_transaction_type
+
+
+@pytest.mark.unit
+def test_classify_transaction_type():
+    fetched_ids = [3, 4, 5, 6, 7, 10]
+    database_ids = [3, 4, 5, 6, 7, 8, 9]
+
+    result = classify_transaction_type(fetched_ids, database_ids)
+
+    result.create == [10]
+    result.delete == [8, 9]
+    result.update == [3, 4, 5, 6, 7]

--- a/tests/apps/events_database/task_test.py
+++ b/tests/apps/events_database/task_test.py
@@ -3,7 +3,7 @@ import pytest
 from busy_beaver.models import ApiUser
 from busy_beaver.apps.events_database.task import (
     sync_database_with_fetched_events,
-    start_sync_events_database_task,
+    start_sync_event_database_task,
 )
 from busy_beaver.factories.event import EventFactory
 from busy_beaver.factories.event_details import EventDetailsFactory
@@ -32,7 +32,7 @@ def test_start_add_events_task(session, create_api_user, patched_background_task
     api_user = create_api_user("admin")
 
     # Act
-    start_sync_events_database_task(api_user)
+    start_sync_event_database_task(api_user)
 
     # Assert
     api_user = ApiUser.query.get(api_user.id)

--- a/tests/apps/events_database/task_test.py
+++ b/tests/apps/events_database/task_test.py
@@ -2,8 +2,8 @@ import pytest
 
 from busy_beaver.models import ApiUser
 from busy_beaver.apps.events_database.task import (
-    add_new_events_to_database,
-    start_add_new_events_to_database_task,
+    add_events_to_database,
+    start_add_events_to_database_task,
 )
 from busy_beaver.factories.event import EventFactory
 from busy_beaver.factories.event_details import EventDetailsFactory
@@ -19,7 +19,7 @@ MODULE_TO_TEST = "busy_beaver.apps.events_database.task"
 def patched_background_task(patcher, create_fake_background_task):
     return patcher(
         MODULE_TO_TEST,
-        namespace=add_new_events_to_database.__name__,
+        namespace=add_events_to_database.__name__,
         replacement=create_fake_background_task(),
     )
 
@@ -31,7 +31,7 @@ def test_start_add_new_events_task(session, create_api_user, patched_background_
     api_user = create_api_user("admin")
 
     # Act
-    start_add_new_events_to_database_task(api_user)
+    start_add_events_to_database_task(api_user)
 
     # Assert
     api_user = ApiUser.query.get(api_user.id)
@@ -70,7 +70,7 @@ def test_add_all_events_to_database(session, patched_meetup):
     patched_meetup(events=events)
 
     # Act
-    add_new_events_to_database("test_group")
+    add_events_to_database("test_group")
 
     # Assert
     all_events_in_database = Event.query.all()
@@ -95,7 +95,7 @@ def test_add_new_events_to_database(session, patched_meetup):
     patched_meetup(events=events)
 
     # Act
-    add_new_events_to_database("test_group")
+    add_events_to_database("test_group")
 
     # Assert
     all_events_in_database = Event.query.all()
@@ -120,7 +120,7 @@ def test_no_events_added_to_database(session, patched_meetup):
     patched_meetup(events=events)
 
     # Act
-    add_new_events_to_database("test_group")
+    add_events_to_database("test_group")
 
     # Assert
     all_events_in_database = Event.query.all()

--- a/tests/apps/events_database/task_test.py
+++ b/tests/apps/events_database/task_test.py
@@ -2,7 +2,7 @@ import pytest
 
 from busy_beaver.models import ApiUser
 from busy_beaver.apps.events_database.task import (
-    add_events_to_database,
+    sync_database_with_fetched_events,
     start_add_events_to_database_task,
 )
 from busy_beaver.factories.event import EventFactory
@@ -19,7 +19,7 @@ MODULE_TO_TEST = "busy_beaver.apps.events_database.task"
 def patched_background_task(patcher, create_fake_background_task):
     return patcher(
         MODULE_TO_TEST,
-        namespace=add_events_to_database.__name__,
+        namespace=sync_database_with_fetched_events.__name__,
         replacement=create_fake_background_task(),
     )
 
@@ -70,7 +70,7 @@ def test_add_all_events_to_database(session, patched_meetup):
     patched_meetup(events=events)
 
     # Act
-    add_events_to_database("test_group")
+    sync_database_with_fetched_events("test_group")
 
     # Assert
     all_events_in_database = Event.query.all()
@@ -95,7 +95,7 @@ def test_add_new_events_to_database(session, patched_meetup):
     patched_meetup(events=events)
 
     # Act
-    add_events_to_database("test_group")
+    sync_database_with_fetched_events("test_group")
 
     # Assert
     all_events_in_database = Event.query.all()
@@ -120,7 +120,7 @@ def test_no_events_added_to_database(session, patched_meetup):
     patched_meetup(events=events)
 
     # Act
-    add_events_to_database("test_group")
+    sync_database_with_fetched_events("test_group")
 
     # Assert
     all_events_in_database = Event.query.all()

--- a/tests/apps/events_database/task_test.py
+++ b/tests/apps/events_database/task_test.py
@@ -3,7 +3,7 @@ import pytest
 from busy_beaver.models import ApiUser
 from busy_beaver.apps.events_database.task import (
     sync_database_with_fetched_events,
-    start_add_events_to_database_task,
+    start_sync_events_database_task,
 )
 from busy_beaver.factories.event import EventFactory
 from busy_beaver.factories.event_details import EventDetailsFactory
@@ -32,7 +32,7 @@ def test_start_add_events_task(session, create_api_user, patched_background_task
     api_user = create_api_user("admin")
 
     # Act
-    start_add_events_to_database_task(api_user)
+    start_sync_events_database_task(api_user)
 
     # Assert
     api_user = ApiUser.query.get(api_user.id)

--- a/tests/apps/upcoming_events/cards_test.py
+++ b/tests/apps/upcoming_events/cards_test.py
@@ -25,7 +25,7 @@ def test_upcoming_event_to_dict():
 def test_upcoming_event_list():
     events = EventDetailsFactory.create_batch(size=5)
 
-    result = UpcomingEventList("*Upcoming Events*", events)
+    result = UpcomingEventList(events, group_name="ChiPy", image_url="url")
 
     assert len(result) == 3 + 3 * 5  # sections: 3 in the header, each block is 3
     assert isinstance(result[0], Image)

--- a/tests/blueprints/poller/update_events_test.py
+++ b/tests/blueprints/poller/update_events_test.py
@@ -3,7 +3,7 @@ import pytest
 from busy_beaver.models import SyncEventDatabaseTask
 from busy_beaver.apps.events_database.task import (
     sync_database_with_fetched_events,
-    start_add_events_to_database_task,
+    start_sync_events_database_task,
 )
 
 MODULE_TO_TEST = "busy_beaver.blueprints.poller.update_events"
@@ -13,7 +13,7 @@ MODULE_TO_TEST = "busy_beaver.blueprints.poller.update_events"
 def patched_update_events_trigger(mocker, patcher):
     return patcher(
         MODULE_TO_TEST,
-        namespace=start_add_events_to_database_task.__name__,
+        namespace=start_sync_events_database_task.__name__,
         replacement=mocker.Mock(),
     )
 
@@ -38,7 +38,7 @@ def test_poll_twitter_smoke_test(
     create_api_user(username="test_user", token="abcd", role="admin")
 
     # Act
-    client.post("/poll/events", headers={"Authorization": "token abcd"})
+    client.post("/poll/sync-event-database", headers={"Authorization": "token abcd"})
 
     # Assert
     tasks = SyncEventDatabaseTask.query.all()
@@ -54,7 +54,7 @@ def test_poll_events_endpoint_no_token(client, session, create_api_user):
     create_api_user(username="test_user", token="abcd", role="user")
 
     # Act
-    result = client.post("/poll/events")
+    result = client.post("/poll/sync-event-database")
 
     # Assert
     assert result.status_code == 401
@@ -66,7 +66,7 @@ def test_poll_events_endpoint_incorrect_token(client, session, create_api_user):
     create_api_user(username="test_user", token="abcd", role="user")
 
     # Act
-    result = client.post("/poll/events")
+    result = client.post("/poll/sync-event-database")
 
     # Assert
     assert result.status_code == 401
@@ -80,7 +80,9 @@ def test_poll_events_endpoint_success(
     create_api_user(username="test_user", token="abcd", role="admin")
 
     # Act
-    result = client.post("/poll/events", headers={"Authorization": "token abcd"})
+    result = client.post(
+        "/poll/sync-event-database", headers={"Authorization": "token abcd"}
+    )
 
     # Assert
     assert result.status_code == 200

--- a/tests/blueprints/poller/update_events_test.py
+++ b/tests/blueprints/poller/update_events_test.py
@@ -1,6 +1,6 @@
 import pytest
 
-from busy_beaver.models import AddEventsToDatabaseTask
+from busy_beaver.models import SyncEventDatabaseTask
 from busy_beaver.apps.events_database.task import (
     sync_database_with_fetched_events,
     start_add_events_to_database_task,
@@ -41,7 +41,7 @@ def test_poll_twitter_smoke_test(
     client.post("/poll/events", headers={"Authorization": "token abcd"})
 
     # Assert
-    tasks = AddEventsToDatabaseTask.query.all()
+    tasks = SyncEventDatabaseTask.query.all()
     assert len(tasks) == 1
 
 

--- a/tests/blueprints/poller/update_events_test.py
+++ b/tests/blueprints/poller/update_events_test.py
@@ -1,8 +1,8 @@
 import pytest
 
-from busy_beaver.models import NewEventsToDatabaseTask
+from busy_beaver.models import AddEventsToDatabaseTask
 from busy_beaver.apps.events_database.task import (
-    add_events_to_database,
+    sync_database_with_fetched_events,
     start_add_events_to_database_task,
 )
 
@@ -25,7 +25,7 @@ def patched_update_events_trigger(mocker, patcher):
 def patched_background_task(patcher, create_fake_background_task):
     return patcher(
         "busy_beaver.apps.events_database.task",
-        namespace=add_events_to_database.__name__,
+        namespace=sync_database_with_fetched_events.__name__,
         replacement=create_fake_background_task(),
     )
 
@@ -41,7 +41,7 @@ def test_poll_twitter_smoke_test(
     client.post("/poll/events", headers={"Authorization": "token abcd"})
 
     # Assert
-    tasks = NewEventsToDatabaseTask.query.all()
+    tasks = AddEventsToDatabaseTask.query.all()
     assert len(tasks) == 1
 
 

--- a/tests/blueprints/poller/update_events_test.py
+++ b/tests/blueprints/poller/update_events_test.py
@@ -1,9 +1,9 @@
 import pytest
 
-from busy_beaver.models import AddNewEventsToDatabaseTask
+from busy_beaver.models import NewEventsToDatabaseTask
 from busy_beaver.apps.events_database.task import (
-    add_new_events_to_database,
-    start_add_new_events_to_database_task,
+    add_events_to_database,
+    start_add_events_to_database_task,
 )
 
 MODULE_TO_TEST = "busy_beaver.blueprints.poller.update_events"
@@ -13,7 +13,7 @@ MODULE_TO_TEST = "busy_beaver.blueprints.poller.update_events"
 def patched_update_events_trigger(mocker, patcher):
     return patcher(
         MODULE_TO_TEST,
-        namespace=start_add_new_events_to_database_task.__name__,
+        namespace=start_add_events_to_database_task.__name__,
         replacement=mocker.Mock(),
     )
 
@@ -25,7 +25,7 @@ def patched_update_events_trigger(mocker, patcher):
 def patched_background_task(patcher, create_fake_background_task):
     return patcher(
         "busy_beaver.apps.events_database.task",
-        namespace=add_new_events_to_database.__name__,
+        namespace=add_events_to_database.__name__,
         replacement=create_fake_background_task(),
     )
 
@@ -41,7 +41,7 @@ def test_poll_twitter_smoke_test(
     client.post("/poll/events", headers={"Authorization": "token abcd"})
 
     # Assert
-    tasks = AddNewEventsToDatabaseTask.query.all()
+    tasks = NewEventsToDatabaseTask.query.all()
     assert len(tasks) == 1
 
 

--- a/tests/blueprints/poller/update_events_test.py
+++ b/tests/blueprints/poller/update_events_test.py
@@ -3,7 +3,7 @@ import pytest
 from busy_beaver.models import SyncEventDatabaseTask
 from busy_beaver.apps.events_database.task import (
     sync_database_with_fetched_events,
-    start_sync_events_database_task,
+    start_sync_event_database_task,
 )
 
 MODULE_TO_TEST = "busy_beaver.blueprints.poller.update_events"
@@ -13,7 +13,7 @@ MODULE_TO_TEST = "busy_beaver.blueprints.poller.update_events"
 def patched_update_events_trigger(mocker, patcher):
     return patcher(
         MODULE_TO_TEST,
-        namespace=start_sync_events_database_task.__name__,
+        namespace=start_sync_event_database_task.__name__,
         replacement=mocker.Mock(),
     )
 

--- a/tests/models/base_test.py
+++ b/tests/models/base_test.py
@@ -1,0 +1,5 @@
+from busy_beaver.models import BaseModel
+
+
+def test_basemodel_tablename():
+    assert BaseModel.__tablename__ == "basemodel"

--- a/tests/models/task_test.py
+++ b/tests/models/task_test.py
@@ -3,7 +3,7 @@ from redis.exceptions import RedisError
 from rq.exceptions import NoSuchJobError
 
 from busy_beaver.models import (
-    AddEventsToDatabaseTask,
+    SyncEventDatabaseTask,
     PostGitHubSummaryTask,
     PostTweetTask,
     Task,
@@ -156,7 +156,7 @@ def test_post_tweet_task(session):
 #############################
 def test_update_events_database_task(session):
     # Arrange
-    task = AddEventsToDatabaseTask(
+    task = SyncEventDatabaseTask(
         job_id="abcd",
         name="task_created_for_test",
         description="Task created for testing purposes",

--- a/tests/models/task_test.py
+++ b/tests/models/task_test.py
@@ -3,7 +3,7 @@ from redis.exceptions import RedisError
 from rq.exceptions import NoSuchJobError
 
 from busy_beaver.models import (
-    NewEventsToDatabaseTask,
+    AddEventsToDatabaseTask,
     PostGitHubSummaryTask,
     PostTweetTask,
     Task,
@@ -156,7 +156,7 @@ def test_post_tweet_task(session):
 #############################
 def test_update_events_database_task(session):
     # Arrange
-    task = NewEventsToDatabaseTask(
+    task = AddEventsToDatabaseTask(
         job_id="abcd",
         name="task_created_for_test",
         description="Task created for testing purposes",

--- a/tests/models/task_test.py
+++ b/tests/models/task_test.py
@@ -3,7 +3,7 @@ from redis.exceptions import RedisError
 from rq.exceptions import NoSuchJobError
 
 from busy_beaver.models import (
-    AddNewEventsToDatabaseTask,
+    NewEventsToDatabaseTask,
     PostGitHubSummaryTask,
     PostTweetTask,
     Task,
@@ -156,7 +156,7 @@ def test_post_tweet_task(session):
 #############################
 def test_update_events_database_task(session):
     # Arrange
-    task = AddNewEventsToDatabaseTask(
+    task = NewEventsToDatabaseTask(
         job_id="abcd",
         name="task_created_for_test",
         description="Task created for testing purposes",

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -1,4 +1,16 @@
+"""Testing helpers that make life easy"""
+
 from unittest import mock
+
+
+class FakeMeetupAdapter:
+    def __init__(self, events):
+        self.mock = mock.MagicMock()
+        self.events = events
+
+    def get_events(self, *args, **kwargs):
+        self.mock(*args, **kwargs)
+        return self.events
 
 
 class FakeSlackClient:


### PR DESCRIPTION
Closes #162 

Previously we added new events to Meetup. This PR enables us to sync the event database with fetched data. New events are added to db, removed events are deleted from db, and all other events are updated in db.

Also cleaned up names. Always good to boyscout.

### Migrations

1. `migrations/versions/[]_change_column_name_and_add_end_epoch_in_.py`

Improved column name and added field that will enable us to integrate with Google calendar #121 

2. `migrations/versions/[]41__rename_sync_event_task_table_and_update_.py`

Change variable names to match the new workflow.