### PR TITLE
Unfurl links and media by default

### DIFF
--- a/busy_beaver/adapters/slack.py
+++ b/busy_beaver/adapters/slack.py
@@ -26,6 +26,8 @@ class SlackAdapter:
         attachments=None,
         channel=None,
         channel_id=None,
+        unfurl_links=True,
+        unfurl_media=True,
     ):
         if not channel and not channel_id:
             raise ValueError("Must specify channel or channel_id")
@@ -38,6 +40,8 @@ class SlackAdapter:
             text=message,
             blocks=blocks,
             attachments=attachments,
+            unfurl_links=unfurl_links,
+            unfurl_media=unfurl_media,
         )
 
     def _get_channel_id(self, channel_name: str) -> str:


### PR DESCRIPTION
Closes #167 

> By default we unfurl all links in any messages posted by users. For messages posted via incoming webhooks, the chat.postMessage API method or chat.postEphemeral, we will unfurl links to media, but not other links.
>
> If you'd like to override these defaults on a per-message basis you can pass unfurl_links or unfurl_media while posting that message. unfurl_links applies to text based content, unfurl_media applies to media based content. These flags are mutually exclusive, the unfurl_links flag has no effect on media content.

from [Slack docs](https://api.slack.com/docs/message-link-unfurling#classic_unfurling)