### PR TITLE
Add healthchecks to CRON with setup instructions

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -54,6 +54,7 @@ aws_secret_access_key = []
 
 ## Deployment Workflow
 
+1. Set environment variables in Ansible control environment: `HEALTHCHECK_GITHUB_SUMMARY`, `HEALTHCHECK_TWITTER_POLLER`, `HEALTHCHECK_SYNC_EVENTS_DATABASE`, `HEALTHCHECK_POST_UPCOMING_EVENTS`; grab uuid values from healthchecks.io
 1. `pip install ansible` installed the machine you will be deploying from
-2. Check to see what the ansible playbook would do, we can run `ansible-playbook -i ./hosts site.yml --ask-sudo-pass -C`
-3. Remove `-C` option to run playbook to deploy app
+1. Check to see what the ansible playbook would do, we can run `ansible-playbook -i ./hosts site.yml --ask-sudo-pass -C`
+1. Remove `-C` option to run playbook to deploy app

--- a/ansible/roles/cron/tasks/main.yml
+++ b/ansible/roles/cron/tasks/main.yml
@@ -5,14 +5,14 @@
     state: present
     minute: 0
     hour: 19
-    job: "/bin/bash {{ run_summary }}"
+    job: "/bin/bash {{ run_summary }} && curl -fsS --retry 3 https://hc-ping.com/{{ lookup('env', 'HEALTHCHECK_GITHUB_SUMMARY') }} > /dev/null"
 
 - cron:
     name: Run Twitter poller to retweet new posts to Slack
     user: "{{ user }}"
     state: present
     minute: "*/13"
-    job: "/bin/bash {{ twitter_poller }}"
+    job: "/bin/bash {{ twitter_poller }} && curl -fsS --retry 3 https://hc-ping.com/{{ lookup('env', 'HEALTHCHECK_TWITTER_POLLER') }} > /dev/null"
 
 - cron:
     name: Backup database and upload to S3
@@ -28,7 +28,7 @@
     state: present
     minute: 0
     hour: 0
-    job: "/bin/bash {{ events_poller }}"
+    job: "/bin/bash {{ events_poller }} && curl -fsS --retry 3 https://hc-ping.com/{{ lookup('env', 'HEALTHCHECK_SYNC_EVENTS_DATABASE') }} > /dev/null"
 
 - cron:
     name: Post Upcoming Events in announcements channel
@@ -37,4 +37,4 @@
     minute: 0
     hour: 14
     weekday: 1
-    job: "/bin/bash {{ upcoming_events }}"
+    job: "/bin/bash {{ upcoming_events }} && curl -fsS --retry 3 https://hc-ping.com/{{ lookup('env', 'HEALTHCHECK_POST_UPCOMING_EVENTS') }} > /dev/null"


### PR DESCRIPTION
While we definitely need an Airflow instance once we are in multiple workspaces, for now we can use healthchecks.io to monitor the status of CRON jobs that keep the lights on. Will need to manually set up CRON for each new workspace Busy Beaver gets installed in.

This workaround allows us to focus on implementing features that will enable us to learn more and iterate on the product to improve it. We can delay setting up Airflow another few weeks.