### PR TITLE
Upgrade to pytest 5.0.0

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+markers =
+    unit
+    integration
+    end2end
+    smoke

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,7 +5,7 @@ ipython
 pdbpp
 pip-tools
 pre-commit==1.14.4
-pytest-cov==2.6.0
+pytest-cov==2.7.1
 pytest-freezegun==0.3.0.post1
 pytest-mock==1.10.0
 pytest-vcr==1.0.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -9,6 +9,6 @@ pytest-cov==2.6.0
 pytest-freezegun==0.3.0.post1
 pytest-mock==1.10.0
 pytest-vcr==1.0.1
-pytest==4.0.1
+pytest==5.0.0
 responses==0.10.6
 vcrpy==2.0.1

--- a/tests/apps/events_database/task_test.py
+++ b/tests/apps/events_database/task_test.py
@@ -117,7 +117,6 @@ def test_delete_all_events_in_database(session, factory, patched_meetup):
 
 
 @pytest.mark.integration
-@pytest.mark.current
 def test_sync_database(session, factory, patched_meetup):
     """
     GIVEN: table has upcoming events, fetched events contains events

--- a/tests/apps/github_summary/task_test.py
+++ b/tests/apps/github_summary/task_test.py
@@ -186,7 +186,6 @@ def test_fetch_github_summary_post_to_slack_with_activity(
 @pytest.mark.vcr()
 @pytest.mark.freeze_time("2019-03-31")
 @pytest.mark.integration
-@pytest.mark.wip
 def test_post_github_summary_task__integration(
     session, factory, t_minus_one_day, patched_slack
 ):


### PR DESCRIPTION
This is more for vanity than anything else. Have some warnings with the upgrade, but they are explained in the [CHANGELOG](https://docs.pytest.org/en/latest/changelog.html#pytest-5-0-0-2019-06-28) (we are moving from 4.0.1).

### Changes

- Added custom marks to `pytest.ini`
- Have a warning for `pytest-freezegun` marks; there is a [PR open with a fix](https://github.com/ktosiek/pytest-freezegun/pull/14)