### PR TITLE
Upgrade to slackclient==2.1.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -18,7 +18,7 @@ redis<3.2  # Redis is pinend to 3.2, something in testing wasn't working and thi
 requests-oauthlib==1.2.0
 requests==2.20.1
 sentry-sdk[flask]==0.7.8
-slackclient==1.3.0
+slackclient==2.1.0
 sqlalchemy-utils==0.34.0
 SQLAlchemy==1.3.1
 transitions==0.6.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,12 +4,15 @@
 #
 #    pip-compile --output-file=requirements.txt requirements.in
 #
+aiohttp==3.5.4            # via slackclient
 alembic==1.0.3
 asn1crypto==0.24.0        # via cryptography
+async-timeout==3.0.1      # via aiohttp
+attrs==19.1.0             # via aiohttp
 blinker==1.4              # via sentry-sdk
 certifi==2019.3.9         # via requests, sentry-sdk
 cffi==1.12.3              # via cryptography
-chardet==3.0.4            # via requests
+chardet==3.0.4            # via aiohttp, requests
 click==7.0                # via flask, rq
 croniter==0.3.30          # via rq-scheduler
 cryptography==2.7
@@ -21,7 +24,7 @@ flask-sqlalchemy==2.4.0
 flask-talisman==0.7.0
 flask==1.0.2
 gunicorn==19.9.0
-idna==2.7                 # via requests
+idna==2.7                 # via requests, yarl
 inflect==2.1.0
 itsdangerous==1.1.0       # via flask
 jinja2==2.10.1            # via flask
@@ -29,6 +32,7 @@ mako==1.0.12              # via alembic
 markupsafe==1.1.1         # via jinja2, mako
 marshmallow==3.0.0rc7
 meetup-api==0.1.1
+multidict==4.5.2          # via aiohttp, yarl
 oauthlib==3.0.1           # via requests-oauthlib
 psycopg2-binary==2.7.7
 pycparser==2.19           # via cffi
@@ -43,13 +47,13 @@ requests==2.20.1
 rq-scheduler==0.9         # via flask-rq2
 rq==1.0                   # via flask-rq2, rq-scheduler
 sentry-sdk[flask]==0.7.8
-six==1.12.0               # via cryptography, faker, flask-talisman, meetup-api, python-dateutil, slackclient, sqlalchemy-utils, transitions, tweepy, websocket-client
-slackclient==1.3.0
+six==1.12.0               # via cryptography, faker, flask-talisman, meetup-api, python-dateutil, sqlalchemy-utils, transitions, tweepy
+slackclient==2.1.0
 sqlalchemy-utils==0.34.0
 sqlalchemy==1.3.1
 text-unidecode==1.2       # via faker
 transitions==0.6.9
 tweepy==3.7.0
 urllib3==1.24.3           # via requests, sentry-sdk
-websocket-client==0.56.0  # via slackclient
 werkzeug==0.15.4          # via flask
+yarl==1.3.0               # via aiohttp

--- a/tests/adapters/cassettes/test_slack_dm.yaml
+++ b/tests/adapters/cassettes/test_slack_dm.yaml
@@ -1,160 +1,81 @@
 interactions:
 - request:
-    body: channel=U5FTQ3QRZ&text=test&unfurl_links=True&unfurl_media=True&as_user=True
+    body: null
     headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
       Content-Type:
-      - application/x-www-form-urlencoded
+      - application/json;charset=utf-8
+      User-Agent:
+      - Python/3.7.1 slackclient/2.1.0 Linux/4.9.125-linuxkit
       authorization:
       - DUMMY
-      user-agent:
-      - slackclient/1.3.0 Python/3.7.1 Linux/4.9.125-linuxkit
     method: POST
-    uri: https://slack.com/api/chat.postMessage
+    uri: https://www.slack.com/api/chat.postMessage
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA32NQQuCQBCF/8ucJXaNXXCP1joQFCZG3cJyqCg13BEK8b83XTp2fN/3Hm+E7g6O
-        +4EiOF+rtqUHOFh6LEpbzHOIgIMAbaxOtDWJnikVa6VENBRCdSFwI5w6Pt5q6aV+Faeoc/wO30+R
-        v5oAerEApsCShkC9pJ1HPGyNz/5dMVWNqNKgyhbrzR6m6QOh5jBFuQAAAA==
+      string: '{"ok":true,"channel":"DEGRT6R3P","ts":"1562423009.000200","message":{"bot_id":"BEJ2BG1PG","type":"message","text":"test","user":"UEGGXQ5EF","ts":"1562423009.000200","team":"T5G0FCMNW"}}'
     headers:
-      Access-Control-Allow-Headers:
-      - slack-route, x-slack-version-ts
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - x-slack-req-id
-      Cache-Control:
-      - private, no-cache, no-store, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Encoding:
-      - gzip
-      Content-Length:
-      - '157'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Sun, 30 Jun 2019 17:43:11 GMT
-      Expires:
-      - Mon, 26 Jul 1997 05:00:00 GMT
-      Pragma:
-      - no-cache
-      Referrer-Policy:
-      - no-referrer
-      Server:
-      - Apache
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Vary:
-      - Accept-Encoding
-      Via:
-      - 1.1 90ec1457c46fc15b8daff1254c3211b7.cloudfront.net (CloudFront)
-      X-Accepted-OAuth-Scopes:
-      - chat:write:user,client
-      X-Amz-Cf-Id:
-      - GD767Hr5LD3IJ2De_c5v3cW-lG_l9FuwDj2gY1Z2xBNzx8q1Qod9pg==
-      X-Amz-Cf-Pop:
-      - IND6
-      X-Cache:
-      - Miss from cloudfront
-      X-Content-Type-Options:
-      - nosniff
-      X-OAuth-Scopes:
-      - identify,bot:basic
-      X-Slack-Req-Id:
-      - da681e6d-b46f-4b93-b2f6-54c159c6ee7a
-      X-Via:
-      - haproxy-www-482q
-      X-XSS-Protection:
-      - '0'
+      ? !!python/object/new:multidict._istr.istr
+      - Access-Control-Allow-Headers
+      : slack-route, x-slack-version-ts
+      ? !!python/object/new:multidict._istr.istr
+      - Access-Control-Allow-Origin
+      : '*'
+      ? !!python/object/new:multidict._istr.istr
+      - Access-Control-Expose-Headers
+      : x-slack-req-id, retry-after
+      ? !!python/object/new:multidict._istr.istr
+      - Cache-Control
+      : private, no-cache, no-store, must-revalidate
+      ? !!python/object/new:multidict._istr.istr
+      - Connection
+      : keep-alive
+      ? !!python/object/new:multidict._istr.istr
+      - Content-Encoding
+      : gzip
+      ? !!python/object/new:multidict._istr.istr
+      - Content-Length
+      : '157'
+      ? !!python/object/new:multidict._istr.istr
+      - Content-Type
+      : application/json; charset=utf-8
+      ? !!python/object/new:multidict._istr.istr
+      - Date
+      : Sat, 06 Jul 2019 14:23:29 GMT
+      ? !!python/object/new:multidict._istr.istr
+      - Expires
+      : Mon, 26 Jul 1997 05:00:00 GMT
+      ? !!python/object/new:multidict._istr.istr
+      - Pragma
+      : no-cache
+      Referrer-Policy: no-referrer
+      ? !!python/object/new:multidict._istr.istr
+      - Server
+      : Apache
+      Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+      ? !!python/object/new:multidict._istr.istr
+      - Vary
+      : Accept-Encoding
+      ? !!python/object/new:multidict._istr.istr
+      - Via
+      : 1.1 0dfd4a767fdb169a154f978de9887037.cloudfront.net (CloudFront)
+      X-Accepted-OAuth-Scopes: chat:write:user,client
+      X-Amz-Cf-Id: 8NR5v2IYGb5uscKxBENOClhKGnYGWYehLwzbPyre-c34Yrdz2B3NAA==
+      X-Amz-Cf-Pop: ORD52-C2
+      X-Cache: Miss from cloudfront
+      X-Content-Type-Options: nosniff
+      X-OAuth-Scopes: identify,bot:basic
+      X-Slack-Req-Id: cd600fe1-a1e3-4bae-b13b-8a05145bcdcc
+      X-Via: haproxy-www-d90e
+      X-XSS-Protection: '0'
     status:
       code: 200
       message: OK
-- request:
-    body: channel=U5FTQ3QRZ&text=test&unfurl_links=True&unfurl_media=True&as_user=True
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/x-www-form-urlencoded
-      authorization:
-      - DUMMY
-      user-agent:
-      - slackclient/1.3.0 Python/3.7.1 Linux/4.9.125-linuxkit
-    method: POST
-    uri: https://slack.com/api/chat.postMessage
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA32NwQrCMBBE/2XPRZJoAuZYTQOCUktFbxLroqJtpdmCUvrvrhePHue9GWaA9g6W
-        uh4TqK6hafABFpbOF6UppjkkQJGB1EbOpTFiNhFCKSFY1BhjuCDYAU4tHW9n7qVupVIvc/8dvp8s
-        fzUG+CIGhJE49RE7Tjvn/WGrXfbvijDUrErtRbZYb/Ywjh8p3zwUuQAAAA==
-    headers:
-      Access-Control-Allow-Headers:
-      - slack-route, x-slack-version-ts
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - x-slack-req-id
-      Cache-Control:
-      - private, no-cache, no-store, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Encoding:
-      - gzip
-      Content-Length:
-      - '157'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Sun, 30 Jun 2019 17:43:24 GMT
-      Expires:
-      - Mon, 26 Jul 1997 05:00:00 GMT
-      Pragma:
-      - no-cache
-      Referrer-Policy:
-      - no-referrer
-      Server:
-      - Apache
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Vary:
-      - Accept-Encoding
-      Via:
-      - 1.1 90ae7a2049c2513b89b7c6134cad70b6.cloudfront.net (CloudFront)
-      X-Accepted-OAuth-Scopes:
-      - chat:write:user,client
-      X-Amz-Cf-Id:
-      - uZdtiCK_bnuxvw4_cO1nFEnnku94gfrbrzZ6QmeCNXpGy5L_kSWFdQ==
-      X-Amz-Cf-Pop:
-      - IND6
-      X-Cache:
-      - Miss from cloudfront
-      X-Content-Type-Options:
-      - nosniff
-      X-OAuth-Scopes:
-      - identify,bot:basic
-      X-Slack-Req-Id:
-      - fcc5dcbd-5e2c-40c2-a056-35c44405e5c8
-      X-Via:
-      - haproxy-www-hjmi
-      X-XSS-Protection:
-      - '0'
-    status:
-      code: 200
-      message: OK
+    url: !!python/object/new:yarl.URL
+      state: !!python/tuple
+      - !!python/object/new:urllib.parse.SplitResult
+        - https
+        - www.slack.com
+        - /api/chat.postMessage
+        - ''
+        - ''
 version: 1

--- a/tests/adapters/cassettes/test_slack_get_channel_info.yaml
+++ b/tests/adapters/cassettes/test_slack_get_channel_info.yaml
@@ -2,167 +2,83 @@ interactions:
 - request:
     body: null
     headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
+      Content-Type:
+      - application/x-www-form-urlencoded;charset=utf-8
+      User-Agent:
+      - Python/3.7.1 slackclient/2.1.0 Linux/4.9.125-linuxkit
       authorization:
       - DUMMY
-      user-agent:
-      - slackclient/1.3.0 Python/3.7.1 Linux/4.9.125-linuxkit
-    method: POST
-    uri: https://slack.com/api/channels.list
+    method: GET
+    uri: https://www.slack.com/api/channels.info?channel=C5GQNTS07
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+WVXW/aMBSG/4rlm91ARSAJH3esUKaVotHSdes0IZOcgEtsR7YDYxX/fTafycZE
-        u65dpd0Q++Dj8+a8T+x7LKa4oWUKBRxMCOcQK9z4co9piBv41Dsb9CuX5x4uYE4YmJAkPBTMzKka
-        bhJ2+RKIBpPnuHWvUvZ8310tIzKY0Jn9IyKxglVsDBwkiXehlMeUT+2a0mYjIU2165WA/uXtRsCQ
-        C8lITL/blTktakJkvoSQ4wNRBmwEMhtJJJ0Z3blFCWW7+TrDdiUn57rd7H1s31z07Pjs9rxT989b
-        dtzp+CXfa37AXwtYi4QGuHGPZyRObft6ghfnQk7RiHANEpk3QHNiR4EQ8erBZ6Ya0VRwnG2FmcRE
-        6aECbZq0LOAklYlQkN29iZKYBIAiIRHfVCpKiK0tKIopi2LCCigiUUT5uIAmIhxDMbG/yKTc0ZF5
-        0+IdsQ+0EOmbECUSIjPRAk0BEiRSjUSEmJC2SpAqs3GuyhaikyPiJcyoSNXQump7a5rFUzbcNdtd
-        FnYQdvq9wVWpuodwS89fo3Cd+kcQ5rS8QgrtuPuu235/MThI5KlgCeGL4pyGYHDkIuUBMOBareG0
-        5o6I9ZkRra2Ex1I5mFC15QKZoaVTA2HrkoFgLOU0WBG/KpkTcYKacbxajjYtQKaZiHKkM9s+lTZv
-        T1v79OpTq1W/3tM2StViBMR8lkMNSh+hznMrTtWtluvPe/YdFPUP8TuE1qNJeaKL5YyLN61a5XPV
-        zbtYXHfsqIOeU/Kr9fLzO5gT9MLuvQbHnL1jZ93WZbvfe5txTOiiZdtcVUcdqznlUsV5bsd+FvR/
-        O9bp+gOnXsuclIEIFw85Ij3HdRzXqz3Zrswt96tdeTUvfzY++Ap+tIcbCLe3H/5dT/Yb7Xpef4jJ
-        laWJSFCJ4ApMWJOQaGIVcPimh0Eq1VrrcvkDL45re0EMAAA=
+      string: '{"ok":true,"channel":{"id":"C5GQNTS07","name":"general","is_channel":true,"created":1495325664,"is_archived":false,"is_general":true,"unlinked":0,"creator":"U5FTQ3QRZ","name_normalized":"general","is_read_only":false,"is_shared":false,"is_org_shared":false,"is_member":true,"is_private":false,"is_mpim":false,"last_read":"1560902428.000100","latest":{"type":"message","subtype":"bot_message","text":"test","ts":"1562423010.003600","username":"BusyBeaverDev","bot_id":"BEJ2BG1PG"},"unread_count":13,"unread_count_display":11,"members":["U5FTQ3QRZ","UEANVEWMN","UEGGXQ5EF","UFZKG96KD","UGG6065AP","UGLHLEJMT","UKZF9G2SH"],"topic":{"value":"Company-wide
+        announcements and work-based matters","creator":"","last_set":0},"purpose":{"value":"This
+        channel is for team-wide communication and announcements. All team members
+        are in this channel.","creator":"","last_set":0},"previous_names":[]}}'
     headers:
-      Access-Control-Allow-Headers:
-      - slack-route, x-slack-version-ts
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - x-slack-req-id
-      Cache-Control:
-      - private, no-cache, no-store, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Encoding:
-      - gzip
-      Content-Length:
-      - '719'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Sun, 31 Mar 2019 20:13:02 GMT
-      Expires:
-      - Mon, 26 Jul 1997 05:00:00 GMT
-      Pragma:
-      - no-cache
-      Referrer-Policy:
-      - no-referrer
-      Server:
-      - Apache
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Vary:
-      - Accept-Encoding
-      Via:
-      - 1.1 6ca6a5c7e4ef3511c3ea6d058e2252f9.cloudfront.net (CloudFront)
-      X-Accepted-OAuth-Scopes:
-      - channels:read,read
-      X-Amz-Cf-Id:
-      - mI_qPeqopEbFp0FBGlcsvrChSMBCw1jnMXmq1H0dhelPdn3MbbavUQ==
-      X-Cache:
-      - Miss from cloudfront
-      X-Content-Type-Options:
-      - nosniff
-      X-OAuth-Scopes:
-      - identify,bot:basic
-      X-Slack-Req-Id:
-      - bf8060a5-439c-4d6c-bf6e-bc803589f895
-      X-Via:
-      - haproxy-www-b3u7
-      X-XSS-Protection:
-      - '0'
+      ? !!python/object/new:multidict._istr.istr
+      - Access-Control-Allow-Headers
+      : slack-route, x-slack-version-ts
+      ? !!python/object/new:multidict._istr.istr
+      - Access-Control-Allow-Origin
+      : '*'
+      ? !!python/object/new:multidict._istr.istr
+      - Access-Control-Expose-Headers
+      : x-slack-req-id, retry-after
+      ? !!python/object/new:multidict._istr.istr
+      - Cache-Control
+      : private, no-cache, no-store, must-revalidate
+      ? !!python/object/new:multidict._istr.istr
+      - Connection
+      : keep-alive
+      ? !!python/object/new:multidict._istr.istr
+      - Content-Encoding
+      : gzip
+      ? !!python/object/new:multidict._istr.istr
+      - Content-Length
+      : '502'
+      ? !!python/object/new:multidict._istr.istr
+      - Content-Type
+      : application/json; charset=utf-8
+      ? !!python/object/new:multidict._istr.istr
+      - Date
+      : Sat, 06 Jul 2019 14:26:02 GMT
+      ? !!python/object/new:multidict._istr.istr
+      - Expires
+      : Mon, 26 Jul 1997 05:00:00 GMT
+      ? !!python/object/new:multidict._istr.istr
+      - Pragma
+      : no-cache
+      Referrer-Policy: no-referrer
+      ? !!python/object/new:multidict._istr.istr
+      - Server
+      : Apache
+      Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+      ? !!python/object/new:multidict._istr.istr
+      - Vary
+      : Accept-Encoding
+      ? !!python/object/new:multidict._istr.istr
+      - Via
+      : 1.1 e9df1c8f21e296ac8b108870aadd91f7.cloudfront.net (CloudFront)
+      X-Accepted-OAuth-Scopes: channels:read,read
+      X-Amz-Cf-Id: yBlVMbEL-L01VTRHPtEbZi-F14KT5z7RXWEZFW20P7Ly0v4z2ty72A==
+      X-Amz-Cf-Pop: ORD52-C2
+      X-Cache: Miss from cloudfront
+      X-Content-Type-Options: nosniff
+      X-OAuth-Scopes: identify,bot:basic
+      X-Slack-Req-Id: b292edb2-9b5a-4369-a7af-a2742fa08950
+      X-Via: haproxy-www-qtt5
+      X-XSS-Protection: '0'
     status:
       code: 200
       message: OK
-- request:
-    body: channel=C5GQNTS07
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '17'
-      Content-Type:
-      - application/x-www-form-urlencoded
-      authorization:
-      - DUMMY
-      user-agent:
-      - slackclient/1.3.0 Python/3.7.1 Linux/4.9.125-linuxkit
-    method: POST
-    uri: https://slack.com/api/channels.info
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA4VRXWvCMBT9KyHPTty0HfZNnHbMD+ZWN3BIie3VBvNRklRx4n9fUjtpYbC3e0/P
-        uef05IzlHgdGFdDCSUaEAIaDM6YpDvDQCxfz6L3ziFtYEA4W2oEARZgFqI5v/EqugBiwwvte3+s+
-        eL7fK2lEJRk9uA9bwjSU2O+dSloIRsXeUTrVHams29IbR4vu4m1VBYiFVJww+u2YzSxWk8ZSsFPd
-        RWdENX2l2v2BcuAbUHUkV/Rgf6ZByim/7VeFxsFXI+RyNJh/jD5nczePV5Ow70+e3ByGfsf3Bq/l
-        PH2ejl5mEV63sJE5TVzhB8IKV/BQ8pyI092RpoBsvbIQCXAQRtstRUep9ncboiFFnBjjItQLswsj
-        2sQajK3y0sJ5oXKpoe4QZVSj6umQHbdSIQOEXy0TyXkhaEIMlaK0bIRoowFjJR1VFSBbJqICmdrZ
-        9j+hFByoLHTs3tR1uL5cfgD8akn3iAIAAA==
-    headers:
-      Access-Control-Allow-Headers:
-      - slack-route, x-slack-version-ts
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - x-slack-req-id
-      Cache-Control:
-      - private, no-cache, no-store, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Encoding:
-      - gzip
-      Content-Length:
-      - '367'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Sun, 31 Mar 2019 20:13:02 GMT
-      Expires:
-      - Mon, 26 Jul 1997 05:00:00 GMT
-      Pragma:
-      - no-cache
-      Referrer-Policy:
-      - no-referrer
-      Server:
-      - Apache
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Vary:
-      - Accept-Encoding
-      Via:
-      - 1.1 9beef7f4d5d93ab1724fe013eb38c198.cloudfront.net (CloudFront)
-      X-Accepted-OAuth-Scopes:
-      - channels:read,read
-      X-Amz-Cf-Id:
-      - VxvuRjipOy9OhFaAtDO02RzTRlQPjO9_DV1MuLNgTlM0nYilvDpDpQ==
-      X-Cache:
-      - Miss from cloudfront
-      X-Content-Type-Options:
-      - nosniff
-      X-OAuth-Scopes:
-      - identify,bot:basic
-      X-Slack-Req-Id:
-      - f13a2ed8-2788-4843-999d-77339c071ee6
-      X-Via:
-      - haproxy-www-j0xn
-      X-XSS-Protection:
-      - '0'
-    status:
-      code: 200
-      message: OK
+    url: !!python/object/new:yarl.URL
+      state: !!python/tuple
+      - !!python/object/new:urllib.parse.SplitResult
+        - https
+        - www.slack.com
+        - /api/channels.info
+        - channel=C5GQNTS07
+        - ''
 version: 1

--- a/tests/adapters/cassettes/test_slack_get_user_timezone.yaml
+++ b/tests/adapters/cassettes/test_slack_get_user_timezone.yaml
@@ -1,89 +1,83 @@
 interactions:
 - request:
-    body: user=U5FTQ3QRZ&include_locale=True
+    body: null
     headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '34'
       Content-Type:
-      - application/x-www-form-urlencoded
+      - application/x-www-form-urlencoded;charset=utf-8
+      User-Agent:
+      - Python/3.7.1 slackclient/2.1.0 Linux/4.9.125-linuxkit
       authorization:
       - DUMMY
-      user-agent:
-      - slackclient/1.3.0 Python/3.7.1 Linux/4.9.125-linuxkit
-    method: POST
-    uri: https://slack.com/api/users.info
+    method: GET
+    uri: https://www.slack.com/api/users.info?include_locale=True&user=U5FTQ3QRZ
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA61V22rbQBD9FbOQPvmiayQbQhtc3KcW0jgUikGMpZG08UordtdpnOB/z+gSV6LN
-        m0Cg2TNnzp7Zh5lXJg9sZdQRp+yoUbHVK+MJW7EHf7O9c+9+/mZTZhCKqEG3/jdrs/7+4xehJRRI
-        EIiT5k+PnJAEBRokXgpCk2AshSRFtkyvlxgQQSGIqKu7FafJfVdoXmqgQMVj2C3WOf0y2eCRgD0K
-        yq6xNArE5CucBM9yM9lykmkoMk01Graa2aFlWVNWKZlygXUrhps6YESscll2oT6cqi78yNEFj0qp
-        ChD8pe5rQEm4rgScov+8Qy8zrO+RtAFz1JHBZ9O5agEsJOUHyHPFFRguS7ai9uAJDKgoB50TLdsn
-        4C/jFO3EphIsgIveRV+yGpjHsqBkypU2vW4JEvAXeW+MF5Bh5HgE5cZUerVb7BYa46PCeaba62vF
-        3aKNd4ueh9BJvCBw/WDvWNeeY6Fn2+H8sco+6xvH+5TcNJJX7u2Vs6EP5lpAfJhhkmGtSZBl7a9d
-        +vMiqwnNFbqNIsuyrZnjzasyuxh1ndGNus4oRl1nYNQLRzfqhaMY9cKB0WD8Fw3GedFg+KL2cnyn
-        pDmKVdIZePXt8b2S5iheSafz2ptKUQylLGkUi3Ya1VtgsALO1JqOICl4+b5C6Cz/lPUauZwrRf2r
-        0z+4Qm1o3vf3BaFHQVP+g9xemv4RqipqV1aHHasEmhLb98PQ9SzXpgEnqYF6umE5e7hn5/Mb99j6
-        hvIGAAA=
+      string: '{"ok":true,"user":{"id":"U5FTQ3QRZ","team_id":"T5G0FCMNW","name":"alysivji","deleted":false,"color":"9f69e7","real_name":"Aly
+        Sivji","tz":"America\/Chicago","tz_label":"Central Daylight Time","tz_offset":-18000,"profile":{"title":"","phone":"","skype":"","real_name":"Aly
+        Sivji","real_name_normalized":"Aly Sivji","display_name":"alysivji","display_name_normalized":"alysivji","status_text":"","status_emoji":"","status_expiration":0,"avatar_hash":"gbda59cfe1d1","email":"alysivji@gmail.com","first_name":"Aly","last_name":"Sivji","image_24":"https:\/\/secure.gravatar.com\/avatar\/bda59cfe1d182d477357b206420e4118.jpg?s=24&d=https%3A%2F%2Fa.slack-edge.com%2F00b63%2Fimg%2Favatars%2Fava_0010-24.png","image_32":"https:\/\/secure.gravatar.com\/avatar\/bda59cfe1d182d477357b206420e4118.jpg?s=32&d=https%3A%2F%2Fa.slack-edge.com%2F00b63%2Fimg%2Favatars%2Fava_0010-32.png","image_48":"https:\/\/secure.gravatar.com\/avatar\/bda59cfe1d182d477357b206420e4118.jpg?s=48&d=https%3A%2F%2Fa.slack-edge.com%2F00b63%2Fimg%2Favatars%2Fava_0010-48.png","image_72":"https:\/\/secure.gravatar.com\/avatar\/bda59cfe1d182d477357b206420e4118.jpg?s=72&d=https%3A%2F%2Fa.slack-edge.com%2F00b63%2Fimg%2Favatars%2Fava_0010-72.png","image_192":"https:\/\/secure.gravatar.com\/avatar\/bda59cfe1d182d477357b206420e4118.jpg?s=192&d=https%3A%2F%2Fa.slack-edge.com%2F00b63%2Fimg%2Favatars%2Fava_0010-192.png","image_512":"https:\/\/secure.gravatar.com\/avatar\/bda59cfe1d182d477357b206420e4118.jpg?s=512&d=https%3A%2F%2Fa.slack-edge.com%2F00b63%2Fimg%2Favatars%2Fava_0010-512.png","status_text_canonical":"","team":"T5G0FCMNW"},"is_admin":true,"is_owner":true,"is_primary_owner":true,"is_restricted":false,"is_ultra_restricted":false,"is_bot":false,"is_app_user":false,"updated":1558834031,"locale":"en-US"}}'
     headers:
-      Access-Control-Allow-Headers:
-      - slack-route, x-slack-version-ts
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - x-slack-req-id
-      Cache-Control:
-      - private, no-cache, no-store, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Encoding:
-      - gzip
-      Content-Length:
-      - '575'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Sun, 30 Jun 2019 17:39:50 GMT
-      Expires:
-      - Mon, 26 Jul 1997 05:00:00 GMT
-      Pragma:
-      - no-cache
-      Referrer-Policy:
-      - no-referrer
-      Server:
-      - Apache
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Vary:
-      - Accept-Encoding
-      Via:
-      - 1.1 638e2f6ec35874dad86fe2250f19c411.cloudfront.net (CloudFront)
-      X-Accepted-OAuth-Scopes:
-      - users:read,read
-      X-Amz-Cf-Id:
-      - mfsXIvUwqKN0DiOVFLzkhc4mxZ0RcF0YbsgaSkzpRKn8wJjMLIULtQ==
-      X-Amz-Cf-Pop:
-      - IND6
-      X-Cache:
-      - Miss from cloudfront
-      X-Content-Type-Options:
-      - nosniff
-      X-OAuth-Scopes:
-      - identify,bot:basic
-      X-Slack-Req-Id:
-      - 567c4853-a9bf-4062-8321-968888db44f6
-      X-Via:
-      - haproxy-www-4qov
-      X-XSS-Protection:
-      - '0'
+      ? !!python/object/new:multidict._istr.istr
+      - Access-Control-Allow-Headers
+      : slack-route, x-slack-version-ts
+      ? !!python/object/new:multidict._istr.istr
+      - Access-Control-Allow-Origin
+      : '*'
+      ? !!python/object/new:multidict._istr.istr
+      - Access-Control-Expose-Headers
+      : x-slack-req-id, retry-after
+      ? !!python/object/new:multidict._istr.istr
+      - Cache-Control
+      : private, no-cache, no-store, must-revalidate
+      ? !!python/object/new:multidict._istr.istr
+      - Connection
+      : keep-alive
+      ? !!python/object/new:multidict._istr.istr
+      - Content-Encoding
+      : gzip
+      ? !!python/object/new:multidict._istr.istr
+      - Content-Length
+      : '575'
+      ? !!python/object/new:multidict._istr.istr
+      - Content-Type
+      : application/json; charset=utf-8
+      ? !!python/object/new:multidict._istr.istr
+      - Date
+      : Sat, 06 Jul 2019 14:23:29 GMT
+      ? !!python/object/new:multidict._istr.istr
+      - Expires
+      : Mon, 26 Jul 1997 05:00:00 GMT
+      ? !!python/object/new:multidict._istr.istr
+      - Pragma
+      : no-cache
+      Referrer-Policy: no-referrer
+      ? !!python/object/new:multidict._istr.istr
+      - Server
+      : Apache
+      Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+      ? !!python/object/new:multidict._istr.istr
+      - Vary
+      : Accept-Encoding
+      ? !!python/object/new:multidict._istr.istr
+      - Via
+      : 1.1 851ddb32cd4fb6ca4503e357c5e6a0cd.cloudfront.net (CloudFront)
+      X-Accepted-OAuth-Scopes: users:read,read
+      X-Amz-Cf-Id: OCh4HlKE6nirqgSYeO3sMDqJMYgVLptnROgV8mpIoYDYVmQ6X-tY_A==
+      X-Amz-Cf-Pop: ORD52-C2
+      X-Cache: Miss from cloudfront
+      X-Content-Type-Options: nosniff
+      X-OAuth-Scopes: identify,bot:basic
+      X-Slack-Req-Id: fe7a0d8c-1f99-4e69-8b5f-d34f093e24cf
+      X-Via: haproxy-www-107g
+      X-XSS-Protection: '0'
     status:
       code: 200
       message: OK
+    url: !!python/object/new:yarl.URL
+      state: !!python/tuple
+      - !!python/object/new:urllib.parse.SplitResult
+        - https
+        - www.slack.com
+        - /api/users.info
+        - include_locale=True&user=U5FTQ3QRZ
+        - ''
 version: 1

--- a/tests/adapters/cassettes/test_slack_post_ephemeral_message_success.yaml
+++ b/tests/adapters/cassettes/test_slack_post_ephemeral_message_success.yaml
@@ -1,80 +1,81 @@
 interactions:
 - request:
-    body: text=test&channel=CEWD83Y74&user=U5FTQ3QRZ
+    body: null
     headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '42'
       Content-Type:
-      - application/x-www-form-urlencoded
+      - application/json;charset=utf-8
+      User-Agent:
+      - Python/3.7.1 slackclient/2.1.0 Linux/4.9.125-linuxkit
       authorization:
       - DUMMY
-      user-agent:
-      - slackclient/1.3.0 Python/3.7.1 Linux/4.9.125-linuxkit
     method: POST
-    uri: https://slack.com/api/chat.postEphemeral
+    uri: https://www.slack.com/api/chat.postEphemeral
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA6tWys9WsiopKk3VUcpNLS5OTE+NLylWslIyNDUztDQ0NzAy1TMwMDE1MFCqBQA3
-        CLkkLAAAAA==
+      string: '{"ok":true,"message_ts":"1562423009.000200"}'
     headers:
-      Access-Control-Allow-Headers:
-      - slack-route, x-slack-version-ts
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - x-slack-req-id
-      Cache-Control:
-      - private, no-cache, no-store, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Encoding:
-      - gzip
-      Content-Length:
-      - '64'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Sun, 30 Jun 2019 17:50:25 GMT
-      Expires:
-      - Mon, 26 Jul 1997 05:00:00 GMT
-      Pragma:
-      - no-cache
-      Referrer-Policy:
-      - no-referrer
-      Server:
-      - Apache
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Vary:
-      - Accept-Encoding
-      Via:
-      - 1.1 3765ff5ab7256fdbff87302f60a6d801.cloudfront.net (CloudFront)
-      X-Accepted-OAuth-Scopes:
-      - chat:write:bot,post
-      X-Amz-Cf-Id:
-      - X8jBOwhzOUnKPfHAdjbpHO_i0-iQJNMddg6_mhAwZfsPiLzPInsrZg==
-      X-Amz-Cf-Pop:
-      - ORD50-C1
-      X-Cache:
-      - Miss from cloudfront
-      X-Content-Type-Options:
-      - nosniff
-      X-OAuth-Scopes:
-      - identify,bot:basic
-      X-Slack-Req-Id:
-      - 6f4e840b-e361-40f6-8a7f-0227564a2e45
-      X-Via:
-      - haproxy-www-0te2
-      X-XSS-Protection:
-      - '0'
+      ? !!python/object/new:multidict._istr.istr
+      - Access-Control-Allow-Headers
+      : slack-route, x-slack-version-ts
+      ? !!python/object/new:multidict._istr.istr
+      - Access-Control-Allow-Origin
+      : '*'
+      ? !!python/object/new:multidict._istr.istr
+      - Access-Control-Expose-Headers
+      : x-slack-req-id, retry-after
+      ? !!python/object/new:multidict._istr.istr
+      - Cache-Control
+      : private, no-cache, no-store, must-revalidate
+      ? !!python/object/new:multidict._istr.istr
+      - Connection
+      : keep-alive
+      ? !!python/object/new:multidict._istr.istr
+      - Content-Encoding
+      : gzip
+      ? !!python/object/new:multidict._istr.istr
+      - Content-Length
+      : '64'
+      ? !!python/object/new:multidict._istr.istr
+      - Content-Type
+      : application/json; charset=utf-8
+      ? !!python/object/new:multidict._istr.istr
+      - Date
+      : Sat, 06 Jul 2019 14:23:29 GMT
+      ? !!python/object/new:multidict._istr.istr
+      - Expires
+      : Mon, 26 Jul 1997 05:00:00 GMT
+      ? !!python/object/new:multidict._istr.istr
+      - Pragma
+      : no-cache
+      Referrer-Policy: no-referrer
+      ? !!python/object/new:multidict._istr.istr
+      - Server
+      : Apache
+      Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+      ? !!python/object/new:multidict._istr.istr
+      - Vary
+      : Accept-Encoding
+      ? !!python/object/new:multidict._istr.istr
+      - Via
+      : 1.1 17256fd1010bade0d64432a8527fd53c.cloudfront.net (CloudFront)
+      X-Accepted-OAuth-Scopes: chat:write:bot,post
+      X-Amz-Cf-Id: 3vNL6oDbSemdxJHvzgcAPl01CXrQFgLGs1F3mkLW8g1AhaixIFtj-A==
+      X-Amz-Cf-Pop: ORD52-C2
+      X-Cache: Miss from cloudfront
+      X-Content-Type-Options: nosniff
+      X-OAuth-Scopes: identify,bot:basic
+      X-Slack-Req-Id: cd1295bb-613c-4351-a43f-9acb51f3fb21
+      X-Via: haproxy-www-sneq
+      X-XSS-Protection: '0'
     status:
       code: 200
       message: OK
+    url: !!python/object/new:yarl.URL
+      state: !!python/tuple
+      - !!python/object/new:urllib.parse.SplitResult
+        - https
+        - www.slack.com
+        - /api/chat.postEphemeral
+        - ''
+        - ''
 version: 1

--- a/tests/adapters/cassettes/test_slack_post_message_success.yaml
+++ b/tests/adapters/cassettes/test_slack_post_message_success.yaml
@@ -2,163 +2,80 @@ interactions:
 - request:
     body: null
     headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
+      Content-Type:
+      - application/json;charset=utf-8
+      User-Agent:
+      - Python/3.7.1 slackclient/2.1.0 Linux/4.9.125-linuxkit
       authorization:
       - DUMMY
-      user-agent:
-      - slackclient/1.3.0 Python/3.7.1 Linux/4.9.125-linuxkit
     method: POST
-    uri: https://slack.com/api/channels.list
+    uri: https://www.slack.com/api/chat.postMessage
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+WVXW/aMBSG/4rlm91ARSAJH3esUKaVotHSdes0IZOcgEtsR7YDYxX/fTafycZE
-        u65dpd0Q++Dj8+a8T+x7LKa4oWUKBRxMCOcQK9z4co9piBv41Dsb9CuX5x4uYE4YmJAkPBTMzKka
-        bhJ2+RKIBpPnuHWvUvZ8310tIzKY0Jn9IyKxglVsDBwkiXehlMeUT+2a0mYjIU2165WA/uXtRsCQ
-        C8lITL/blTktakJkvoSQ4wNRBmwEMhtJJJ0Z3blFCWW7+TrDdiUn57rd7H1s31z07Pjs9rxT989b
-        dtzp+CXfa37AXwtYi4QGuHGPZyRObft6ghfnQk7RiHANEpk3QHNiR4EQ8erBZ6Ya0VRwnG2FmcRE
-        6aECbZq0LOAklYlQkN29iZKYBIAiIRHfVCpKiK0tKIopi2LCCigiUUT5uIAmIhxDMbG/yKTc0ZF5
-        0+IdsQ+0EOmbECUSIjPRAk0BEiRSjUSEmJC2SpAqs3GuyhaikyPiJcyoSNXQump7a5rFUzbcNdtd
-        FnYQdvq9wVWpuodwS89fo3Cd+kcQ5rS8QgrtuPuu235/MThI5KlgCeGL4pyGYHDkIuUBMOBareG0
-        5o6I9ZkRra2Ex1I5mFC15QKZoaVTA2HrkoFgLOU0WBG/KpkTcYKacbxajjYtQKaZiHKkM9s+lTZv
-        T1v79OpTq1W/3tM2StViBMR8lkMNSh+hznMrTtWtluvPe/YdFPUP8TuE1qNJeaKL5YyLN61a5XPV
-        zbtYXHfsqIOeU/Kr9fLzO5gT9MLuvQbHnL1jZ93WZbvfe5txTOiiZdtcVUcdqznlUsV5bsd+FvR/
-        O9bp+gOnXsuclIEIFw85Ij3HdRzXqz3Zrswt96tdeTUvfzY++Ap+tIcbCLe3H/5dT/Yb7Xpef4jJ
-        laWJSFCJ4ApMWJOQaGIVcPimh0Eq1VrrcvkDL45re0EMAAA=
+      string: '{"ok":true,"channel":"C5GQNTS07","ts":"1562423010.003600","message":{"type":"message","subtype":"bot_message","text":"test","ts":"1562423010.003600","username":"BusyBeaverDev","bot_id":"BEJ2BG1PG"}}'
     headers:
-      Access-Control-Allow-Headers:
-      - slack-route, x-slack-version-ts
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - x-slack-req-id
-      Cache-Control:
-      - private, no-cache, no-store, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Encoding:
-      - gzip
-      Content-Length:
-      - '719'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Sun, 31 Mar 2019 20:24:48 GMT
-      Expires:
-      - Mon, 26 Jul 1997 05:00:00 GMT
-      Pragma:
-      - no-cache
-      Referrer-Policy:
-      - no-referrer
-      Server:
-      - Apache
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Vary:
-      - Accept-Encoding
-      Via:
-      - 1.1 0e31b6655e8230805e58fd71c1351ba1.cloudfront.net (CloudFront)
-      X-Accepted-OAuth-Scopes:
-      - channels:read,read
-      X-Amz-Cf-Id:
-      - pQMnscaLflvfWDd0x7xOYWZmo7Jq-gRLEDn4poiRmK7EZG-R2S4q3Q==
-      X-Cache:
-      - Miss from cloudfront
-      X-Content-Type-Options:
-      - nosniff
-      X-OAuth-Scopes:
-      - identify,bot:basic
-      X-Slack-Req-Id:
-      - 0ab3b7fa-bd5a-4a2d-93a4-e5321fbe0511
-      X-Via:
-      - haproxy-www-85xl
-      X-XSS-Protection:
-      - '0'
+      ? !!python/object/new:multidict._istr.istr
+      - Access-Control-Allow-Headers
+      : slack-route, x-slack-version-ts
+      ? !!python/object/new:multidict._istr.istr
+      - Access-Control-Allow-Origin
+      : '*'
+      ? !!python/object/new:multidict._istr.istr
+      - Access-Control-Expose-Headers
+      : x-slack-req-id, retry-after
+      ? !!python/object/new:multidict._istr.istr
+      - Cache-Control
+      : private, no-cache, no-store, must-revalidate
+      ? !!python/object/new:multidict._istr.istr
+      - Connection
+      : keep-alive
+      ? !!python/object/new:multidict._istr.istr
+      - Content-Encoding
+      : gzip
+      ? !!python/object/new:multidict._istr.istr
+      - Content-Length
+      : '156'
+      ? !!python/object/new:multidict._istr.istr
+      - Content-Type
+      : application/json; charset=utf-8
+      ? !!python/object/new:multidict._istr.istr
+      - Date
+      : Sat, 06 Jul 2019 14:23:30 GMT
+      ? !!python/object/new:multidict._istr.istr
+      - Expires
+      : Mon, 26 Jul 1997 05:00:00 GMT
+      ? !!python/object/new:multidict._istr.istr
+      - Pragma
+      : no-cache
+      Referrer-Policy: no-referrer
+      ? !!python/object/new:multidict._istr.istr
+      - Server
+      : Apache
+      Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+      ? !!python/object/new:multidict._istr.istr
+      - Vary
+      : Accept-Encoding
+      ? !!python/object/new:multidict._istr.istr
+      - Via
+      : 1.1 11f2bbed05b5b40cdf20119c85254bcf.cloudfront.net (CloudFront)
+      X-Accepted-OAuth-Scopes: chat:write:bot,post
+      X-Amz-Cf-Id: 7t2MAeDEKeooaJXFdJpis5awZsNzo0wlVWxdDwbHUW2322ctOW5Y1A==
+      X-Amz-Cf-Pop: ORD52-C2
+      X-Cache: Miss from cloudfront
+      X-Content-Type-Options: nosniff
+      X-OAuth-Scopes: identify,bot:basic
+      X-Slack-Req-Id: 98c68d82-81aa-4605-8929-e12313cc6a2b
+      X-Via: haproxy-www-bgad
+      X-XSS-Protection: '0'
     status:
       code: 200
       message: OK
-- request:
-    body: channel=C5GQNTS07&text=test
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '27'
-      Content-Type:
-      - application/x-www-form-urlencoded
-      authorization:
-      - DUMMY
-      user-agent:
-      - slackclient/1.3.0 Python/3.7.1 Linux/4.9.125-linuxkit
-    method: POST
-    uri: https://slack.com/api/chat.postMessage
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA33MQQvCMAyG4f+S85BUrc4dJzLwIMq8S6dhDl0nTSqOsf9uC6I3T4HnJd8A3Q0y
-        cZ4SOF+NtXSHDNa6OOyOJS4hAeEASus5LmZpupogokIMoSVmUxNkA0j/CPcrCbCvPlZ1cvq50EsC
-        CrH8m/ZMzpo2/uee+5zMk1wppm5sHXLcbC4xbrbTvFD7AsbxDbTQEBzKAAAA
-    headers:
-      Access-Control-Allow-Headers:
-      - slack-route, x-slack-version-ts
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - x-slack-req-id
-      Cache-Control:
-      - private, no-cache, no-store, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Encoding:
-      - gzip
-      Content-Length:
-      - '159'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Sun, 31 Mar 2019 20:24:49 GMT
-      Expires:
-      - Mon, 26 Jul 1997 05:00:00 GMT
-      Pragma:
-      - no-cache
-      Referrer-Policy:
-      - no-referrer
-      Server:
-      - Apache
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Vary:
-      - Accept-Encoding
-      Via:
-      - 1.1 eece9b48dfd62f662117c631fa9b910f.cloudfront.net (CloudFront)
-      X-Accepted-OAuth-Scopes:
-      - chat:write:bot,post
-      X-Amz-Cf-Id:
-      - v0d8VQuBBtlFKfR4CZsqi-_tVqm4ttcVLACd6xybR9JktwrbIVG8kg==
-      X-Cache:
-      - Miss from cloudfront
-      X-Content-Type-Options:
-      - nosniff
-      X-OAuth-Scopes:
-      - identify,bot:basic
-      X-Slack-Req-Id:
-      - bd7c6b88-3dd6-45ef-9349-bc01aba6713d
-      X-Via:
-      - haproxy-www-o93
-      X-XSS-Protection:
-      - '0'
-    status:
-      code: 200
-      message: OK
+    url: !!python/object/new:yarl.URL
+      state: !!python/tuple
+      - !!python/object/new:urllib.parse.SplitResult
+        - https
+        - www.slack.com
+        - /api/chat.postMessage
+        - ''
+        - ''
 version: 1

--- a/tests/adapters/slack_test.py
+++ b/tests/adapters/slack_test.py
@@ -25,10 +25,10 @@ def test_slack_dm(slack: SlackAdapter):
 @pytest.mark.vcr()
 def test_slack_get_channel_info(slack: SlackAdapter):
     # Act
-    result = slack.get_channel_info("general")
+    result = slack.get_channel_info("C5GQNTS07")
 
     # Assert
-    assert result.name == "general"
+    assert result.name == "C5GQNTS07"
     assert len(result.members) > 0
 
 


### PR DESCRIPTION
The [python-slackclient](https://github.com/slackapi/python-slackclient/) is 2.x; we should upgrade as this version will stop being supported on Jan 1, 2020.

As we using the adapter pattern, upgrading is a matter of adding pinning to a new version and making sure all adapter tests pass. Made the changes outlined in the [migration guide](https://github.com/slackapi/python-slackclient/wiki/Slack-Python-SDK-Roadmap) and updated a test to use a slack adapter versus a request mock as the new slack client uses `aiohttp` behind the scene.