### PR TITLE
Send logs to Loggly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
 
 language: python
 python:
-  - "3.7"
+  - "3.8"
 
 env:
   - PYTHONPATH=. FLASK_APP=busy_beaver/__init__.py FLASK_ENV=development DATABASE_URI="postgresql://postgres@127.0.0.1:5432/busy_beaver_test" REDIS_URI="redis://127.0.0.1:6379" IMAGE_NAME="alysivji/busy-beaver" OAUTHLIB_INSECURE_TRANSPORT=1 OAUTHLIB_RELAX_TOKEN_SCOPE=1

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -38,8 +38,8 @@ export TWITTER_ACCESS_TOKEN_SECRET=[]
 export YOUTUBE_API_KEY=[]
 export YOUTUBE_CHANNEL=[]
 
-export SENTRY_DSN=[sentry-dsn]
-export DATADOG_API_KEY=[datadog-api-key]
+export BUSYBEAVER_SENTRY_DSN=[sentry-dsn]
+export BUSYBEAVER_LOGGLY_TOKEN=[api-key]
 ```
 
 ## Deployment Workflow

--- a/busy_beaver/__init__.py
+++ b/busy_beaver/__init__.py
@@ -1,6 +1,5 @@
 import logging
 from logging.config import dictConfig as load_dict_config
-import pathlib
 import sentry_sdk
 from sentry_sdk.integrations.flask import FlaskIntegration
 from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
@@ -27,10 +26,6 @@ from .config import (
     TWITTER_CONSUMER_KEY,
     TWITTER_CONSUMER_SECRET,
 )
-
-# Forgot why I do this... probalby should have commented as it is not ovious
-# TODO test if it is needed in datadog
-pathlib.Path("logs").mkdir(exist_ok=True)
 
 # observability
 load_dict_config(LOGGING_CONFIG)

--- a/busy_beaver/config.py
+++ b/busy_beaver/config.py
@@ -59,17 +59,16 @@ LOGGING_CONFIG = {
         },
     },
     "handlers": {
-        "console": {"class": "logging.StreamHandler", "formatter": "standard"},
-        "datadog_file": {
-            "class": "logging.FileHandler",
-            "filename": "logs/busy_beaver_log.json",
-            "mode": "w",
+        "console": {"class": "logging.StreamHandler", "formatter": "json"},
+        "loggly": {
+            "class": "logging.handlers.SysLogHandler",
+            "address": ("loggly", 514),
             "formatter": "json",
         },
     },
     "loggers": {
         "busy_beaver": {
-            "handlers": ["datadog_file"] if IN_PRODUCTION else ["console"],
+            "handlers": ["loggly"],  # if IN_PRODUCTION else ["console"],
             "level": "INFO" if IN_PRODUCTION else "DEBUG",
         }
     },

--- a/busy_beaver/config.py
+++ b/busy_beaver/config.py
@@ -56,10 +56,11 @@ LOGGING_CONFIG = {
         "json": {
             "class": "pythonjsonlogger.jsonlogger.JsonFormatter",
             "format": "%(asctime)s %(levelname)s %(filename)s %(funcName)s %(lineno)s %(message)s",  # noqa
+            "datefmt": "%Y-%m-%d %H:%M:%S",
         },
     },
     "handlers": {
-        "console": {"class": "logging.StreamHandler", "formatter": "json"},
+        "console": {"class": "logging.StreamHandler", "formatter": "standard"},
         "loggly": {
             "class": "logging.handlers.SysLogHandler",
             "address": ("loggly", 514),
@@ -68,7 +69,7 @@ LOGGING_CONFIG = {
     },
     "loggers": {
         "busy_beaver": {
-            "handlers": ["loggly"],  # if IN_PRODUCTION else ["console"],
+            "handlers": ["console", "loggly"] if IN_PRODUCTION else ["console"],
             "level": "INFO" if IN_PRODUCTION else "DEBUG",
         }
     },

--- a/busy_beaver/config.py
+++ b/busy_beaver/config.py
@@ -63,13 +63,13 @@ LOGGING_CONFIG = {
         "console": {"class": "logging.StreamHandler", "formatter": "standard"},
         "loggly": {
             "class": "logging.handlers.SysLogHandler",
-            "address": ("loggly", 514),
+            "address": ("loggly", 514) if IN_PRODUCTION else "/dev/log",
             "formatter": "json",
         },
     },
     "loggers": {
         "busy_beaver": {
-            "handlers": ["console", "loggly"] if IN_PRODUCTION else ["console"],
+            "handlers": ["console"] if IN_PRODUCTION else ["console"],
             "level": "INFO" if IN_PRODUCTION else "DEBUG",
         }
     },

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -28,13 +28,15 @@ services:
     image: alysivji/busy-beaver:latest
     command: webserver
     restart: always
+    depends_on: &app_depends_on
+      - loggly
     environment: &app_env_vars
       IN_PRODUCTION: 1
       PYTHONPATH: .
       FLASK_APP: /app/busy_beaver/__init__.py
       DATABASE_URI: ${DATABASE_URI}
       REDIS_URI: ${REDIS_URI}
-      SENTRY_DSN: ${SENTRY_DSN}
+      SENTRY_DSN: ${BUSYBEAVER_SENTRY_DSN}
       OAUTHLIB_INSECURE_TRANSPORT: 1
       OAUTHLIB_RELAX_TOKEN_SCOPE: 1
       SECRET_KEY: ${SECRET_KEY}
@@ -53,8 +55,6 @@ services:
       TWITTER_CONSUMER_KEY: ${TWITTER_CONSUMER_KEY}
       TWITTER_CONSUMER_SECRET: ${TWITTER_CONSUMER_SECRET}
       YOUTUBE_API_KEY: ${YOUTUBE_API_KEY}
-    volumes: &app_volumes
-      - bb-logs:/app/logs/
     networks:
       - sivnet
       - local
@@ -69,8 +69,8 @@ services:
     image: alysivji/busy-beaver:latest
     command: worker
     restart: always
+    depends_on: *app_depends_on
     environment: *app_env_vars
-    volumes: *app_volumes
     networks:
       - local
     labels:
@@ -78,7 +78,7 @@ services:
       - traefik.enable=false
 
   # agents to support busy-beaver
-  watchtower: #  restart app container when new releases
+  watchtower:  # restart app container when new releases
     image: v2tec/watchtower
     command: --label-enable --cleanup
     volumes:
@@ -87,43 +87,11 @@ services:
       - local
     labels:
       - traefik.enable=false
-  datadog:  # collect logs
-    build: datadog
-    depends_on:
-      - app
-    links:
-      - app
+  loggly:  # collect logs
+    image: sendgridlabs/loggly-docker
     environment:
-      - DD_API_KEY=${DATADOG_API_KEY}
-      - DD_HOSTNAME=busybeaver.sivji.com
-      - DD_LOGS_ENABLED=true
-      - DD_ENABLE_PAYLOADS_EVENTS=false
-      - DD_ENABLE_PAYLOADS_SERIES=false
-      - DD_ENABLE_PAYLOADS_SERVICE_CHECKS=false
-      - DD_ENABLE_PAYLOADS_SKETCHES=false
-    volumes:
-      - bb-logs:/busy-beaver/logs
-      - /var/run/docker.sock:/var/run/docker.sock
-      - /proc/:/host/proc/:ro
-      - /sys/fs/cgroup:/host/sys/fs/cgroup:ro
-    networks:
-      - local
-    labels:
-      - traefik.enable=false
-
-  # tools
-  admin:
-    image: jeffknupp/sandman2
-    environment:
-      DB_TYPE: postgres
-      DB_DRIVER: psycopg2
-      DB_HOST: ${POSTGRES_HOST}
-      DB_PORT: ${POSTGRES_PORT}
-      DATABASE: ${POSTGRES_DATABASE}
-      USERNAME: ${POSTGRES_USER}
-      PASSWORD: ${POSTGRES_PASSWORD}
-    ports:
-      - 9000:5000
+      TOKEN: ${BUSYBEAVER_LOGGLY_TOKEN}
+      TAG: PROD
     networks:
       - local
     labels:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -8,7 +8,6 @@ networks:
 
 volumes:
   pgdata:
-  bb-logs:
 
 services:
   # infrastructure

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,8 +66,8 @@ services:
     tty: true
 
   # tools
-  loggly:
-    image: sendgridlabs/loggly-docker
-    environment:
-      TOKEN: ${BUSYBEAVER_LOGGLY_TOKEN}
-      TAG: DEV
+  # loggly:
+  #   image: sendgridlabs/loggly-docker
+  #   environment:
+  #     TOKEN: ${BUSYBEAVER_LOGGLY_TOKEN}
+  #     TAG: DEV

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,3 +78,11 @@ services:
       PASSWORD: bbdev_password
     ports:
       - 9000:5000
+  loggly:
+    image: sendgridlabs/loggly-docker
+    environment:
+      TOKEN: 8b18533a-1c9c-4747-9698-db531c81e54b
+      TAG: Docker
+      LOGGLY_DEBUG: 1
+    ports:
+      - 514:514/udp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,23 +66,8 @@ services:
     tty: true
 
   # tools
-  admin:
-    image: jeffknupp/sandman2
-    environment:
-      DB_TYPE: postgres
-      DB_DRIVER: psycopg2
-      DB_HOST: db
-      DB_PORT: 5432
-      DATABASE: busy-beaver
-      USERNAME: bbdev_user
-      PASSWORD: bbdev_password
-    ports:
-      - 9000:5000
   loggly:
     image: sendgridlabs/loggly-docker
     environment:
-      TOKEN: 8b18533a-1c9c-4747-9698-db531c81e54b
-      TAG: Docker
-      LOGGLY_DEBUG: 1
-    ports:
-      - 514:514/udp
+      TOKEN: ${BUSYBEAVER_LOGGLY_TOKEN}
+      TAG: DEV

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -18,8 +18,8 @@ COPY ./ /app
 # Switch from root user for security
 RUN groupadd -g 901 -r busybeaverdev \
     && useradd -g busybeaverdev -r -u 901 busybeaver_user \
-    && mkdir /app/logs /home/busybeaver_user \
-    && chmod -R 777 /app/logs /home/busybeaver_user
+    && mkdir /home/busybeaver_user \
+    && chmod -R 755 /home/busybeaver_user
 USER busybeaver_user
 
 ENTRYPOINT [ "scripts/entrypoint.sh" ]

--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -18,8 +18,8 @@ COPY ./ /app
 # Switch from root user for security
 RUN groupadd -g 901 -r busybeaverdev \
     && useradd -g busybeaverdev -r -u 901 busybeaver_user \
-    && mkdir /app/logs /home/busybeaver_user \
-    && chmod -R 777 /app/logs /home/busybeaver_user
+    && mkdir /home/busybeaver_user \
+    && chmod -R 755 /home/busybeaver_user
 USER busybeaver_user
 
 ENTRYPOINT [ "scripts/entrypoint.sh" ]

--- a/start_async_worker.py
+++ b/start_async_worker.py
@@ -2,6 +2,7 @@ from logging.config import dictConfig as load_dict_config
 
 import sentry_sdk
 from sentry_sdk.integrations.rq import RqIntegration
+from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
 
 from busy_beaver.app import create_app
 from busy_beaver.config import IN_PRODUCTION, LOGGING_CONFIG, SENTRY_DSN
@@ -9,10 +10,10 @@ from busy_beaver.extensions import rq
 from busy_beaver.toolbox.rq import retry_failed_job
 
 # observability
-LOGGING_CONFIG["handlers"]["datadog_file"]["filename"] = "logs/busy_beaver_worker.json"
+# LOGGING_CONFIG["handlers"]["datadog_file"]["filename"] = "logs/busy_beaver_worker.json"
 load_dict_config(LOGGING_CONFIG)
 if IN_PRODUCTION and SENTRY_DSN:
-    sentry_sdk.init(SENTRY_DSN, integrations=[RqIntegration()])
+    sentry_sdk.init(SENTRY_DSN, integrations=[RqIntegration(), SqlalchemyIntegration()])
 
 app = create_app()
 ctx = app.app_context()

--- a/start_async_worker.py
+++ b/start_async_worker.py
@@ -10,7 +10,6 @@ from busy_beaver.extensions import rq
 from busy_beaver.toolbox.rq import retry_failed_job
 
 # observability
-# LOGGING_CONFIG["handlers"]["datadog_file"]["filename"] = "logs/busy_beaver_worker.json"
 load_dict_config(LOGGING_CONFIG)
 if IN_PRODUCTION and SENTRY_DSN:
     sentry_sdk.init(SENTRY_DSN, integrations=[RqIntegration(), SqlalchemyIntegration()])


### PR DESCRIPTION
DataDog client takes up a lot of resources and we only use it for logging. I think it's a good idea to move to a simpler logging solution.

#### Additional Resources

- [Docker Logging Through Syslog](https://www.loggly.com/docs/docker-syslog/)
- [Python dictConfig logging example using SyslogHandle](https://gist.github.com/biggers/7da64042c86f7405f488bcc9efe040f8)