### PR TITLE
Do not display summary information for zero commits

### DIFF
--- a/busy_beaver/apps/github_integration/summary/event_list.py
+++ b/busy_beaver/apps/github_integration/summary/event_list.py
@@ -53,6 +53,10 @@ class CommitsList(EventList):
         repo_noun = inflector.plural(self.NOUN, num_repos)
 
         num_commits = sum([event["payload"]["distinct_size"] for event in self.events])
+
+        if num_commits == 0:
+            return ""
+
         commit_noun = inflector.plural("commit", num_commits)
         return (
             f">{self.EMOJI} {num_commits} {commit_noun} "

--- a/tests/apps/github_integration/summary/event_list_test.py
+++ b/tests/apps/github_integration/summary/event_list_test.py
@@ -69,3 +69,14 @@ def test_issued_open_list_generates_custom_links():
         }
     )
     assert f"<example.com|some_repository#4>" in event_list.generate_summary_text()
+
+
+def test_zero_commits_does_not_produce_a_summary():
+    commits_list = CommitsList()
+    commits_list.append(
+        {
+            "payload": {"distinct_size": 0},
+            "repo": {"name": "some_repository", "url": "api.github.com/repos/"},
+        }
+    )
+    assert not commits_list.generate_summary_text()


### PR DESCRIPTION
Sometimes we see summary information for repos with 0 commits. This doesn't make sense so I'm fixing for the edge case

![image](https://user-images.githubusercontent.com/4369343/74996764-15cf2000-541a-11ea-91cd-327e3092d9fe.png)

### What does this do

Do not display summary information if the number of commits is 0.

### Callouts

n/a

### Dependencies

n/a
