### PR TITLE
Do not require HTTPS on healthcheck endpoint

### DIFF
--- a/busy_beaver/apps/debug/api/healthcheck.py
+++ b/busy_beaver/apps/debug/api/healthcheck.py
@@ -2,11 +2,14 @@ import logging
 
 from flask import blueprints, jsonify
 
+from busy_beaver.extensions import talisman
+
 logger = logging.getLogger(__name__)
 healthcheck_bp = blueprints.Blueprint("healthcheck", __name__)
 
 
 @healthcheck_bp.route("/healthcheck", methods=["GET"])
+@talisman(force_https=False)
 def health_check():
     logger.info("Hit healthcheck")
     return jsonify({"ping": "pong"})


### PR DESCRIPTION
### What does this do

Healthcheck endpoint doesn't need to be HTTPS

Flask Talisman forces all traffic to HTTPS, including internal traffic. Isn't usually isn't a problem as traefik routes all traffic to HTTPS.

When I was building out a staging environment on Kubernetes, the readiness probe was having issues with HTTPS. This fix causes everything to work.

### Callouts

Healthcheck endpoints don't really need to be HTTPS, they can also be HTTP for internal use

### Dependencies

n/a
