### PR TITLE
RQ cleanup work -- probe script and explicit queue name

### DIFF
--- a/busy_beaver/app.py
+++ b/busy_beaver/app.py
@@ -40,7 +40,7 @@ def create_app(*, testing=False):
     migrate.init_app(app, db)
 
     app.config["RQ_REDIS_URL"] = REDIS_URI
-    app.config["RQ_QUEUES"] = ["default", "failed"]
+    app.config["RQ_QUEUES"] = ["busybeaver_default"]
     rq.init_app(app)
 
     talisman.init_app(app)

--- a/scripts/check_worker_box.sh
+++ b/scripts/check_worker_box.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# Check to see if worker box is still active
+# Used for Kubernetes probes
+rq info -u ${REDIS_URI} --only-workers | grep -q ${HOSTNAME}

--- a/start_async_worker.py
+++ b/start_async_worker.py
@@ -18,6 +18,6 @@ app = create_app()
 ctx = app.app_context()
 ctx.push()
 
-w = rq.get_worker("default", "failed")
+w = rq.get_worker("busybeaver_default")
 w.push_exc_handler(retry_failed_job)
 w.work()


### PR DESCRIPTION
More work getting us ready for Kubernetes.

### What does this do

- adding a script to enable us to use probes
- being explicit about the queue name

### Callouts

- we are not using the `failed` queue in a meaningful way

### Dependencies

n/a

### Resources Used

- RQ docs: [Monitoring](https://python-rq.org/docs/monitoring/)
- [How to probe celery workers](https://github.com/celery/celery/issues/4079)
- [Kubernetes liveness probes are dangerous](https://srcco.de/posts/kubernetes-liveness-probes-are-dangerous.html)
- Google k8s Best Practices: [Health checks with readiness and liveness probes](https://cloud.google.com/blog/products/gcp/kubernetes-best-practices-setting-up-health-checks-with-readiness-and-liveness-probes)