### PR TITLE
HOTFIX: Log errors to Sentry

### DIFF
--- a/busy_beaver/config.py
+++ b/busy_beaver/config.py
@@ -66,7 +66,7 @@ LOGGING_CONFIG = {
     },
     "loggers": {
         "busy_beaver": {
-            "handlers": ["loggly"] if IN_PRODUCTION else ["console"],
+            "handlers": ["console"] if IN_PRODUCTION else ["console"],
             "level": "INFO" if IN_PRODUCTION else "DEBUG",
         }
     },


### PR DESCRIPTION
### What does this do

If we use `rsyslog`, errors do not get captured on Sentry. Sentry >> logs. Have it fixed for Kubernetes, so let's not worry about it too much. Just get it fixed

### Why are we doing this

To see errors

### How should this be tested

n/a

### Migrations

n/a

### Dependencies

n/a
