### PR TITLE
Remove loggly handler

### DIFF
--- a/busy_beaver/config.py
+++ b/busy_beaver/config.py
@@ -57,12 +57,7 @@ LOGGING_CONFIG = {
         },
     },
     "handlers": {
-        "console": {"class": "logging.StreamHandler", "formatter": "standard"},
-        "loggly": {
-            "class": "logging.handlers.SysLogHandler",
-            "address": ("loggly", 514) if IN_PRODUCTION else "/dev/log",
-            "formatter": "json",
-        },
+        "console": {"class": "logging.StreamHandler", "formatter": "standard"}
     },
     "loggers": {
         "busy_beaver": {

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -86,12 +86,3 @@ services:
       - local
     labels:
       - traefik.enable=false
-  loggly:  # collect logs
-    image: sendgridlabs/loggly-docker
-    environment:
-      TOKEN: ${BUSYBEAVER_LOGGLY_TOKEN}
-      TAG: PROD
-    networks:
-      - local
-    labels:
-      - traefik.enable=false

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -27,8 +27,6 @@ services:
     image: alysivji/busy-beaver:latest
     command: webserver
     restart: always
-    depends_on: &app_depends_on
-      - loggly
     environment: &app_env_vars
       IN_PRODUCTION: 1
       PYTHONPATH: .
@@ -68,7 +66,6 @@ services:
     image: alysivji/busy-beaver:latest
     command: worker
     restart: always
-    depends_on: *app_depends_on
     environment: *app_env_vars
     networks:
       - local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,10 +62,3 @@ services:
     volumes: *app_volumes
     stdin_open: true
     tty: true
-
-  # tools
-  # loggly:
-  #   image: sendgridlabs/loggly-docker
-  #   environment:
-  #     TOKEN: ${BUSYBEAVER_LOGGLY_TOKEN}
-  #     TAG: DEV


### PR DESCRIPTION
### What does this do

Remove all instances of loggly. We are now using ElasticSearch for logs

### Why are we doing this

Last part before Kubernetes migration can be complete

### How should this be tested

n/a

### Migrations

n/a

### Dependencies

n/a
