### PR TITLE
Update redis from 3.1.0 to 3.4.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ pull-upstream: ## pull from upstream master
 build: ## rebuild containers
 	docker-compose build
 
+changelog:  ## create changelog since release v="version"
+	python scripts/generate_changelog.py --version $(v)
+
 up: ## start local dev environment; run migrations; populate database
 	docker-compose up -d
 	make migrate-up

--- a/deployment/busybeaver/Chart.yaml
+++ b/deployment/busybeaver/Chart.yaml
@@ -6,11 +6,11 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.5.0
+version: 0.5.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 1.4.7
+appVersion: 2.1.1
 
 keywords:
   - community-engagement

--- a/deployment/busybeaver/templates/_helpers.tpl
+++ b/deployment/busybeaver/templates/_helpers.tpl
@@ -53,7 +53,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Environment Variables
 */}}
 {{- define "busybeaver.env_vars" }}
-{{- if eq .Values.environment "production" }}\
+{{- if eq .Values.environment "production" }}
 - name: ENVIRONMENT
   value: {{ .Values.environment }}
 - name: IN_PRODUCTION

--- a/requirements.in
+++ b/requirements.in
@@ -13,7 +13,7 @@ psycopg2-binary==2.8.4
 python-dateutil==2.8.1
 python-json-logger==0.1.11
 pytz==2019.3
-redis<3.2  # Redis is pinend to 3.2, something in testing wasn't working and this fixed it
+redis==3.4.1
 requests-oauthlib==1.3.0
 requests==2.22.0
 sentry-sdk[flask]==0.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ python-dateutil==2.8.1
 python-editor==1.0.4      # via alembic
 python-json-logger==0.1.11
 pytz==2019.3
-redis==3.1.0
+redis==3.4.1
 requests-oauthlib==1.3.0
 requests==2.22.0
 rq-scheduler==0.9         # via flask-rq2


### PR DESCRIPTION
### What does this do

- update redis client
- clean up typos
- update app version in helm

### Why are we doing this

clean up

### How should this be tested

n/a

### Migrations

n/a

### Dependencies

n/a

### Callouts

n/a
