### PR TITLE
Middleware to add tag each request with a uuid

### DIFF
--- a/busy_beaver/common/middleware.py
+++ b/busy_beaver/common/middleware.py
@@ -1,0 +1,18 @@
+import uuid
+
+from werkzeug.wrappers import Request
+
+
+class RequestUuidMiddleware:
+    """Add uuid to each request"""
+
+    def __init__(self, app):
+        self.app = app
+
+    def __call__(self, environ, start_response):
+        request = Request(environ)
+        request_id = request.headers.get("X-Request-ID")
+        if not request_id:
+            request_id = str(uuid.uuid4())
+        environ["request_id"] = request_id
+        return self.app(environ, start_response)

--- a/tests/apps/github_integration/summary/event_list_test.py
+++ b/tests/apps/github_integration/summary/event_list_test.py
@@ -68,7 +68,7 @@ def test_issued_open_list_generates_custom_links():
             "repo": {"name": "some_repository"},
         }
     )
-    assert f"<example.com|some_repository#4>" in event_list.generate_summary_text()
+    assert "<example.com|some_repository#4>" in event_list.generate_summary_text()
 
 
 def test_zero_commits_does_not_produce_a_summary():

--- a/tests/common/middleware_test.py
+++ b/tests/common/middleware_test.py
@@ -1,0 +1,36 @@
+from flask import Flask, request
+import pytest
+
+from busy_beaver.common.middleware import RequestUuidMiddleware
+
+
+@pytest.fixture(scope="session")
+def app():
+    app = Flask(__name__)
+    app.wsgi_app = RequestUuidMiddleware(app.wsgi_app)
+
+    @app.route("/")
+    def hello_world():
+        return request.environ.get("request_id")
+
+    ctx = app.app_context()
+    ctx.push()
+    yield app
+
+    ctx.pop()
+
+
+@pytest.fixture(scope="session")
+def client(app):
+    client = app.test_client()
+    yield client
+
+
+def test_middleware(client):
+    result = client.get("/")
+    assert len(result.data) > 0
+
+
+def test_middleware_with_request_id(client):
+    result = client.get("/", headers={"X-Request-ID": "abc"})
+    assert result.data == b"abc"


### PR DESCRIPTION
### What does this do

Add UUID to request environment.

### Why are we doing this

Will help us track requests throughout the system

### How should this be tested

Test independently

### Migrations

n/a

### Dependencies

n/a

### Callouts

n/a
