### PR TITLE
Identify users that interact with bot via slash command

### DIFF
--- a/busy_beaver/apps/slack_integration/oauth/workflow.py
+++ b/busy_beaver/apps/slack_integration/oauth/workflow.py
@@ -29,23 +29,10 @@ class UserDetails(NamedTuple):
     details: tuple
 
 
-def create_link_to_login_to_settings(slack_id, workspace_id):
-    slack_installation = SlackInstallation.query.filter_by(
-        workspace_id=workspace_id
-    ).first()
-
-    user = SlackUser.query.filter_by(
-        slack_id=slack_id, installation=slack_installation
-    ).first()
-    if not user:
-        logger.info("Creating new account.")
-        user = SlackUser()
-        user.slack_id = slack_id
-        user.installation = slack_installation
-
+def create_link_to_login_to_settings(slack_user):
     auth = slack_signin_oauth.generate_authentication_tuple()
-    user.slack_oauth_state = auth.state
-    db.session.add(user)
+    slack_user.slack_oauth_state = auth.state
+    db.session.add(slack_user)
     db.session.commit()
 
     return Output(SIGN_IN_TO_SLACK, auth.url)

--- a/busy_beaver/apps/slack_integration/slash_command.py
+++ b/busy_beaver/apps/slack_integration/slash_command.py
@@ -116,10 +116,10 @@ def command_not_found(**data):
 @slash_command_dispatcher.on("connect")
 def link_github(**data):
     logger.info("Linking GitHub account for new user", extra=data)
-    slack_id = data["user_id"]
-    workspace_id = data["team_id"]
+    slack_user = data["user"]
+    installation = data["installation"]
 
-    text, url = connect_github_to_slack(slack_id, workspace_id)
+    text, url = connect_github_to_slack(installation, slack_user)
     attachment = create_url_attachment(url, text="Associate GitHub Profile")
     return make_slack_response(text=text, attachments=attachment)
 
@@ -127,10 +127,10 @@ def link_github(**data):
 @slash_command_dispatcher.on("reconnect")
 def relink_github(**data):
     logger.info("Relinking GitHub account", extra=data)
-    slack_id = data["user_id"]
-    workspace_id = data["team_id"]
+    slack_user = data["user"]
+    installation = data["installation"]
 
-    text, url = relink_github_to_slack(slack_id, workspace_id)
+    text, url = relink_github_to_slack(installation, slack_user)
     attachment = create_url_attachment(url, text="Associate GitHub Profile")
     return make_slack_response(text=text, attachments=attachment)
 
@@ -138,10 +138,10 @@ def relink_github(**data):
 @slash_command_dispatcher.on("disconnect")
 def disconnect_github(**data):
     logger.info("Disconnecting GitHub account.")
-    slack_id = data["user_id"]
-    workspace_id = data["team_id"]
+    slack_user = data["user"]
+    installation = data["installation"]
 
-    text, _ = disconnect_github_from_slack(slack_id, workspace_id)
+    text, _ = disconnect_github_from_slack(installation, slack_user)
     return make_slack_response(text=text)
 
 
@@ -151,9 +151,8 @@ def disconnect_github(**data):
 @slash_command_dispatcher.on("settings")
 def login_to_busy_beaver_settings(**data):
     logger.info("Requested settings url", extra=data)
-    slack_id = data["user_id"]
-    workspace_id = data["team_id"]
+    slack_user = data["user"]
 
-    text, url = create_link_to_login_to_settings(slack_id, workspace_id)
+    text, url = create_link_to_login_to_settings(slack_user)
     attachment = create_url_attachment(url, text="Login to Access Settings")
     return make_slack_response(text=text, attachments=attachment)

--- a/tests/_utilities/factories/manager.py
+++ b/tests/_utilities/factories/manager.py
@@ -1,7 +1,7 @@
 from .event import Event
 from .event_details import EventDetails
 from .github_summary_user import GitHubSummaryConfiguration, GitHubSummaryUser
-from .slack import SlackAppHomeOpened, SlackInstallation
+from .slack import SlackAppHomeOpened, SlackInstallation, SlackUser
 from .tweet import Tweet
 
 
@@ -13,6 +13,7 @@ class FactoryManager:
         GitHubSummaryUser,
         SlackAppHomeOpened,
         SlackInstallation,
+        SlackUser,
         Tweet,
     ]
 

--- a/tests/_utilities/factories/slack.py
+++ b/tests/_utilities/factories/slack.py
@@ -2,6 +2,7 @@ import factory
 
 from busy_beaver.models import SlackAppHomeOpened as slack_app_home_opened_model
 from busy_beaver.models import SlackInstallation as slack_installation_model
+from busy_beaver.models import SlackUser as slack_user_model
 
 
 def SlackInstallation(session):
@@ -38,3 +39,16 @@ def SlackAppHomeOpened(session):
         count = 1
 
     return _SlackAppHomeOpenedFactory
+
+
+def SlackUser(session):
+    class _SlackUserFactory(factory.alchemy.SQLAlchemyModelFactory):
+        class Meta:
+            model = slack_user_model
+            sqlalchemy_session_persistence = "commit"
+            sqlalchemy_session = session
+
+        installation = factory.SubFactory(SlackInstallation(session))
+        slack_id = "user_id"
+
+    return _SlackUserFactory

--- a/tests/apps/slack_integration/api/slash_command_test.py
+++ b/tests/apps/slack_integration/api/slash_command_test.py
@@ -1,5 +1,7 @@
 import pytest
 
+from busy_beaver.apps.slack_integration.models import SlackUser
+
 pytest_plugins = ("tests._utilities.fixtures.slack",)
 
 
@@ -8,9 +10,10 @@ pytest_plugins = ("tests._utilities.fixtures.slack",)
 ###################
 @pytest.mark.integration
 def test_slack_command_valid_command(
-    client, create_slack_headers, generate_slash_command_request
+    client, session, factory, create_slack_headers, generate_slash_command_request
 ):
-    data = generate_slash_command_request("help")
+    installation = factory.SlackInstallation()
+    data = generate_slash_command_request("help", team_id=installation.workspace_id)
     headers = create_slack_headers(100_000_000, data, is_json_data=False)
 
     response = client.post("/slack/slash-command", headers=headers, data=data)
@@ -21,9 +24,12 @@ def test_slack_command_valid_command(
 
 @pytest.mark.integration
 def test_slack_command_invalid_command(
-    client, create_slack_headers, generate_slash_command_request
+    client, session, factory, create_slack_headers, generate_slash_command_request
 ):
-    data = generate_slash_command_request("non-existent")
+    installation = factory.SlackInstallation()
+    data = generate_slash_command_request(
+        "non-existent", team_id=installation.workspace_id
+    )
     headers = create_slack_headers(100_000_000, data, is_json_data=False)
 
     response = client.post("/slack/slash-command", headers=headers, data=data)
@@ -34,12 +40,34 @@ def test_slack_command_invalid_command(
 
 @pytest.mark.integration
 def test_slack_command_empty_command(
-    client, create_slack_headers, generate_slash_command_request
+    client, session, factory, create_slack_headers, generate_slash_command_request
 ):
-    data = generate_slash_command_request(command="")
+    installation = factory.SlackInstallation()
+    data = generate_slash_command_request(command="", team_id=installation.workspace_id)
     headers = create_slack_headers(100_000_000, data, is_json_data=False)
 
     response = client.post("/slack/slash-command", headers=headers, data=data)
 
     assert response.status_code == 200
     assert "/busybeaver help" in response.json["text"].lower()
+
+
+@pytest.mark.integration
+def test_slack_command_creates_user_record_in_database(
+    client, session, factory, create_slack_headers, generate_slash_command_request
+):
+    # Arrange
+    installation = factory.SlackInstallation()
+    data = generate_slash_command_request("help", team_id=installation.workspace_id)
+    headers = create_slack_headers(100_000_000, data, is_json_data=False)
+
+    # Act
+    client.post("/slack/slash-command", headers=headers, data=data)
+
+    # Assert
+    users = SlackUser.query.all()
+    assert len(users) == 1
+
+    user = users[0]
+    assert user.slack_id == data["user_id"]
+    assert user.installation.workspace_id == data["team_id"]

--- a/tests/apps/slack_integration/slash_command_test.py
+++ b/tests/apps/slack_integration/slash_command_test.py
@@ -57,12 +57,17 @@ def test_connect_command_new_user(session, factory, generate_slash_command_reque
 def test_connect_command_existing_user(
     session, factory, generate_slash_command_request
 ):
-    user = factory.GitHubSummaryUser(slack_id="existing_user")
+    existing_user = "existing_user"
+    github_user = factory.GitHubSummaryUser(slack_id=existing_user)
+    installation = github_user.configuration.slack_installation
+    slack_user = factory.SlackUser(slack_id=existing_user, installation=installation)
     data = generate_slash_command_request(
         "connect",
-        user_id=user.slack_id,
-        team_id=user.configuration.slack_installation.workspace_id,
+        user_id=github_user.slack_id,
+        team_id=github_user.configuration.slack_installation.workspace_id,
     )
+    data["user"] = slack_user
+    data["installation"] = slack_user.installation
 
     result = link_github(**data)
 

--- a/tests/apps/slack_integration/slash_command_test.py
+++ b/tests/apps/slack_integration/slash_command_test.py
@@ -43,9 +43,13 @@ def test_command_not_found(generate_slash_command_request):
 def test_connect_command_new_user(session, factory, generate_slash_command_request):
     github_summary_config = factory.GitHubSummaryConfiguration()
     install = github_summary_config.slack_installation
+    new_user = "new_user"
+    slack_user = factory.SlackUser(slack_id=new_user, installation=install)
     data = generate_slash_command_request(
-        "connect", user_id="new_user", team_id=install.workspace_id
+        "connect", user_id=new_user, team_id=install.workspace_id
     )
+    data["user"] = slack_user
+    data["installation"] = install
 
     result = link_github(**data)
 
@@ -59,15 +63,13 @@ def test_connect_command_existing_user(
 ):
     existing_user = "existing_user"
     github_user = factory.GitHubSummaryUser(slack_id=existing_user)
-    installation = github_user.configuration.slack_installation
-    slack_user = factory.SlackUser(slack_id=existing_user, installation=installation)
+    install = github_user.configuration.slack_installation
+    slack_user = factory.SlackUser(slack_id=existing_user, installation=install)
     data = generate_slash_command_request(
-        "connect",
-        user_id=github_user.slack_id,
-        team_id=github_user.configuration.slack_installation.workspace_id,
+        "connect", user_id=github_user.slack_id, team_id=install.workspace_id
     )
     data["user"] = slack_user
-    data["installation"] = slack_user.installation
+    data["installation"] = install
 
     result = link_github(**data)
 
@@ -78,9 +80,13 @@ def test_connect_command_existing_user(
 def test_reconnect_command_new_user(session, factory, generate_slash_command_request):
     github_summary_config = factory.GitHubSummaryConfiguration()
     install = github_summary_config.slack_installation
+    new_user = "new_user"
+    slack_user = factory.SlackUser(slack_id=new_user, installation=install)
     data = generate_slash_command_request(
-        "reconnect", user_id="new_user", team_id=install.workspace_id
+        "reconnect", user_id=new_user, team_id=install.workspace_id
     )
+    data["user"] = slack_user
+    data["installation"] = install
 
     result = relink_github(**data)
 
@@ -92,12 +98,15 @@ def test_reconnect_command_new_user(session, factory, generate_slash_command_req
 def test_reconnect_command_existing_user(
     session, factory, generate_slash_command_request
 ):
-    user = factory.GitHubSummaryUser(slack_id="existing_user")
+    existing_user = "existing_user"
+    github_user = factory.GitHubSummaryUser(slack_id=existing_user)
+    install = github_user.configuration.slack_installation
+    slack_user = factory.SlackUser(slack_id=existing_user, installation=install)
     data = generate_slash_command_request(
-        "reconnect",
-        user_id=user.slack_id,
-        team_id=user.configuration.slack_installation.workspace_id,
+        "reconnect", user_id=existing_user, team_id=install.workspace_id
     )
+    data["user"] = slack_user
+    data["installation"] = install
 
     result = relink_github(**data)
 
@@ -111,7 +120,10 @@ def test_disconnect_command_unregistered_user(
 ):
     github_summary_config = factory.GitHubSummaryConfiguration()
     install = github_summary_config.slack_installation
+    slack_user = factory.SlackUser(slack_id="new_user", installation=install)
     data = generate_slash_command_request("disconnect", team_id=install.workspace_id)
+    data["user"] = slack_user
+    data["installation"] = install
 
     result = disconnect_github(**data)
 
@@ -122,17 +134,20 @@ def test_disconnect_command_unregistered_user(
 def test_disconnect_command_registered_user(
     session, factory, generate_slash_command_request
 ):
-    user = factory.GitHubSummaryUser(slack_id="existing_user")
+    existing_user = "existing_user"
+    github_user = factory.GitHubSummaryUser(slack_id=existing_user)
+    install = github_user.configuration.slack_installation
+    slack_user = factory.SlackUser(slack_id=existing_user, installation=install)
     data = generate_slash_command_request(
-        "disconnect",
-        user_id=user.slack_id,
-        team_id=user.configuration.slack_installation.workspace_id,
+        "disconnect", user_id=github_user.slack_id, team_id=install.workspace_id
     )
+    data["user"] = slack_user
+    data["installation"] = install
 
     result = disconnect_github(**data)
 
     assert "Account has been deleted" in result["text"]
-    assert not GitHubSummaryUser.query.get(user.id)
+    assert not GitHubSummaryUser.query.get(github_user.id)
 
 
 #########################


### PR DESCRIPTION
### What does this do

In #274 we added a `slack_user` table.

- add users to this table the first time they interact with Busy Beaver through a slash command.
- attach user and installation to the dictionary that is passed through to each handler function

### Why are we doing this

This will make things easier in the long run.

### How should this be tested

Added tests around functionality I added. Also modified tests we already have to make this work.

It's a bit messy right now, come back to refactor later.

### Migrations

n/a

### Dependencies

n/a

### Callouts

n/a
