### PR TITLE
Display number of posts specified in config

### DIFF
--- a/busy_beaver/apps/slack_integration/blocks.py
+++ b/busy_beaver/apps/slack_integration/blocks.py
@@ -25,9 +25,7 @@ class AppHome:
 
         if upcoming_events_config:
             blocks.extend([Divider(), Section("\n\n\n\n")])
-            blocks.extend(
-                generate_upcoming_events_message(upcoming_events_config, count=5)
-            )
+            blocks.extend(generate_upcoming_events_message(upcoming_events_config))
 
         self.blocks = blocks
 

--- a/busy_beaver/apps/slack_integration/slash_command.py
+++ b/busy_beaver/apps/slack_integration/slash_command.py
@@ -103,7 +103,7 @@ def upcoming_events(**data):
     if not upcoming_events_config.enabled:
         return make_slack_response(text="This feature has been disabled.")
 
-    blocks = generate_upcoming_events_message(upcoming_events_config, count=5)
+    blocks = generate_upcoming_events_message(upcoming_events_config)
     return make_slack_response(blocks=blocks)
 
 

--- a/busy_beaver/apps/upcoming_events/upcoming_events.py
+++ b/busy_beaver/apps/upcoming_events/upcoming_events.py
@@ -5,8 +5,8 @@ from busy_beaver.common.wrappers.meetup import EventDetails
 from busy_beaver.models import Event, UpcomingEventsConfiguration
 
 
-def generate_upcoming_events_message(config: UpcomingEventsConfiguration, count: int):
-    events = _fetch_future_events_from_database(config, count)
+def generate_upcoming_events_message(config: UpcomingEventsConfiguration):
+    events = _fetch_future_events_from_database(config, count=config.post_num_events)
     image_url = config.slack_installation.workspace_logo_url
     return UpcomingEventList(events, image_url).to_dict()
 

--- a/busy_beaver/apps/upcoming_events/workflow.py
+++ b/busy_beaver/apps/upcoming_events/workflow.py
@@ -58,6 +58,6 @@ def post_upcoming_events_message(config_id: str):
     installation = config.slack_installation
     slack = SlackClient(installation.bot_access_token)
 
-    blocks = generate_upcoming_events_message(config, config.post_num_events)
+    blocks = generate_upcoming_events_message(config)
     slack.post_message(blocks=blocks, channel=config.channel)
     set_task_progress(100)

--- a/tests/apps/upcoming_events/upcoming_events_test.py
+++ b/tests/apps/upcoming_events/upcoming_events_test.py
@@ -23,10 +23,11 @@ def test_generate_next_event(session, factory):
 
 @pytest.mark.unit
 def test_generate_upcoming_events_message(session, factory):
-    group = factory.UpcomingEventsGroup()
+    config = factory.UpcomingEventsConfiguration(post_num_events=1)
+    group = factory.UpcomingEventsGroup(configuration=config)
     factory.Event.create_batch(size=10, group=group)
 
-    result = generate_upcoming_events_message(group.configuration, count=1)
+    result = generate_upcoming_events_message(group.configuration)
 
     assert len(result) == 3 + 1 * 3  # sections: 3 in the header, each block is 3
 
@@ -39,7 +40,7 @@ def test_events_from_different_group_are_displayed_correct(session, factory):
     """
     # Arrange
     tomorrow = datetime.utcnow() + timedelta(days=1)
-    config = factory.UpcomingEventsConfiguration()
+    config = factory.UpcomingEventsConfiguration(post_num_events=5)
     group = factory.UpcomingEventsGroup(meetup_urlname="Group 1", configuration=config)
     factory.Event(group=group, name="First event", start_epoch=tomorrow.timestamp())
 
@@ -50,7 +51,7 @@ def test_events_from_different_group_are_displayed_correct(session, factory):
     factory.Event(group=group, name="Second event", start_epoch=next_week.timestamp())
 
     # Act
-    result = generate_upcoming_events_message(group.configuration, count=5)
+    result = generate_upcoming_events_message(group.configuration)
 
     # Assert
     first_event = result[3]


### PR DESCRIPTION
Closes #290 

### What does this do

Use settings stored in the database to show a number of upcoming events.

### Why are we doing this

Final part of multitenancy feature

### How should this be tested

Do current tests pass?

### Migrations

n/a

### Dependencies

n/a

### Callouts

n/a
