### PR TITLE
Download files from git-lfs when building an image

### DIFF
--- a/.github/workflows/build_tag_and_push_image.yaml
+++ b/.github/workflows/build_tag_and_push_image.yaml
@@ -11,6 +11,8 @@ jobs:
       RELEASE_TAG: ${{ github.event.release.tag_name }}
     steps:
       - uses: actions/checkout@v2
+        with:
+          lfs: true
       - name: Login to DockerHub
         run: echo "$DOCKERHUB_ACCESS_TOKEN" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
         env:


### PR DESCRIPTION
Part of #283 

### What does this do

Downloads files from git-lfs when cloning the repo to build an image.

### Why are we doing this

Currently, we are serving file pointers; this change will let us download the file itself when serving static assets. Still good using WhiteNoise to serve static assets. No need to set up a CDN on Digital Ocean just yet.

### How should this be tested

Does this work in production?

### Migrations

n/a

### Dependencies

n/a

### Callouts

n/a
