### PR TITLE
Flash app messages to user; users can only upload pictures

### DIFF
--- a/busy_beaver/apps/web/forms.py
+++ b/busy_beaver/apps/web/forms.py
@@ -78,6 +78,6 @@ class OrganizationLogoForm(FlaskForm):
         "Upload Logo",
         validators=[
             FileRequired(),
-            FileAllowed(["jpg", "png"], "PNG / JPG Images only!"),
+            FileAllowed(["jpg", "jpeg", "png"], "PNG / JPG Images only!"),
         ],
     )

--- a/busy_beaver/apps/web/forms.py
+++ b/busy_beaver/apps/web/forms.py
@@ -1,8 +1,9 @@
 from flask_login import current_user
 from flask_wtf import FlaskForm
+from flask_wtf.file import FileAllowed, FileField, FileRequired
 import pytz
 from wtforms import ValidationError
-from wtforms.fields import FileField, IntegerField, SelectField, StringField
+from wtforms.fields import IntegerField, SelectField, StringField
 from wtforms.validators import DataRequired, NumberRange
 from wtforms_components import TimeField
 
@@ -73,4 +74,10 @@ class OrganizationNameForm(FlaskForm):
 
 
 class OrganizationLogoForm(FlaskForm):
-    logo = FileField("Upload Logo")
+    logo = FileField(
+        "Upload Logo",
+        validators=[
+            FileRequired(),
+            FileAllowed(["jpg", "png"], "PNG / JPG Images only!"),
+        ],
+    )

--- a/busy_beaver/apps/web/forms.py
+++ b/busy_beaver/apps/web/forms.py
@@ -11,6 +11,7 @@ from busy_beaver.clients import meetup
 from busy_beaver.common.datetime_utilities import add_gmt_offset_to_timezone
 from busy_beaver.models import UpcomingEventsGroup
 
+ALLOWED_FILE_TYPES = ["jpg", "jpeg", "png"]
 TIMEZONES = [(pytz.timezone(tz), tz) for tz in pytz.common_timezones]
 TZ_CHOICES = sorted(
     add_gmt_offset_to_timezone(TIMEZONES), key=lambda x: int(x[1][3:5]), reverse=True
@@ -78,6 +79,6 @@ class OrganizationLogoForm(FlaskForm):
         "Upload Logo",
         validators=[
             FileRequired(),
-            FileAllowed(["jpg", "jpeg", "png"], "PNG / JPG Images only!"),
+            FileAllowed(ALLOWED_FILE_TYPES, "PNG / JPG Images only!"),
         ],
     )

--- a/busy_beaver/apps/web/views.py
+++ b/busy_beaver/apps/web/views.py
@@ -1,6 +1,6 @@
 import logging
 
-from flask import jsonify, redirect, render_template, url_for
+from flask import flash, redirect, render_template, url_for
 from flask.views import View
 from flask_login import current_user, login_required, logout_user
 
@@ -103,7 +103,7 @@ def github_summary_settings():
             slack_id=current_user.slack_id,
         )
         logger.info("GitHub Summary settings changed successfully")
-        return jsonify({"message": "Settings changed successfully"})
+        flash("Settings saved", "success")
 
     # load default
     try:
@@ -131,7 +131,8 @@ def toggle_github_summary_config_view():
 
     config = installation.github_summary_config
     if not config:
-        return jsonify({"error": "Need to enter post time and timezone"})
+        flash("Need to enter post time and timezone", "error")
+        return redirect(url_for("web.github_summary_settings"))
     config.toggle_configuration_enabled_status()
     db.session.add(config)
     db.session.commit()
@@ -167,7 +168,7 @@ def upcoming_events_settings():
             slack_id=current_user.slack_id,
         )
         logger.info("Upcoming Events settings changed successfully")
-        return jsonify({"message": "Settings changed successfully"})
+        flash("Settings saved", "success")
 
     # load default
     try:
@@ -216,7 +217,8 @@ def toggle_upcoming_events_config_view():
 
     config = installation.upcoming_events_config
     if not config:
-        return jsonify({"error": "Need to enter post time and timezone"})
+        flash("Need to enter post time and timezone", "error")
+        return redirect(url_for("web.upcoming_events_settings"))
     config.toggle_configuration_enabled_status()
     db.session.add(config)
     db.session.commit()
@@ -236,7 +238,8 @@ def toggle_post_cron_view():
 
     config = installation.upcoming_events_config
     if not config:
-        return jsonify({"error": "Need to enter post time and timezone"})
+        flash("Need to enter post time and timezone", "error")
+        return redirect(url_for("web.upcoming_events_settings"))
     config.toggle_post_cron_enabled_status()
     db.session.add(config)
     db.session.commit()
@@ -262,7 +265,7 @@ def upcoming_events_add_new_group():
             installation, config, meetup_urlname=form.data["meetup_urlname"]
         )
         logger.info("New group added")
-        return jsonify({"message": "Group added successfully"})
+        flash("Settings changed", "success")
 
     # load default
     try:
@@ -314,7 +317,7 @@ def organization_settings():
         db.session.add(installation)
         db.session.commit()
         logger.info("Organization name updated successfully")
-        return jsonify({"message": "Settings changed successfully"})
+        flash("Organization name updated", "success")
 
     # load default
     try:
@@ -351,7 +354,7 @@ def organization_settings_update_logo():
         db.session.add(installation)
         db.session.commit()
         logger.info("Workspace logo saved successfully")
-        return jsonify({"message": "Settings changed successfully"})
+        flash("Logo uploaded", "success")
 
     return redirect(url_for("web.organization_settings"))
 
@@ -372,4 +375,6 @@ def organization_settings_remove_logo():
     db.session.add(installation)
     db.session.commit()
     logger.info("Workspace logo removed")
-    return jsonify({"message": "Settings changed successfully"})
+
+    flash("Logo removed", "success")
+    return redirect(url_for("web.organization_settings"))

--- a/busy_beaver/apps/web/views.py
+++ b/busy_beaver/apps/web/views.py
@@ -347,7 +347,6 @@ def organization_settings_update_logo():
 
     form = OrganizationLogoForm()
     if form.validate_on_submit():
-        # TODO what file types are allowed?
         logger.info("Attempt to save organization logo")
         upload_url = s3.upload_logo(form.data["logo"])
         installation.workspace_logo_url = upload_url
@@ -355,6 +354,8 @@ def organization_settings_update_logo():
         db.session.commit()
         logger.info("Workspace logo saved successfully")
         flash("Logo uploaded", "success")
+    else:
+        flash("Can only upload PNG and JPG images", "error")
 
     return redirect(url_for("web.organization_settings"))
 

--- a/busy_beaver/apps/web/views.py
+++ b/busy_beaver/apps/web/views.py
@@ -336,7 +336,7 @@ def organization_settings():
 
 @web_bp.route("/settings/organization/logo", methods=["POST"])
 @login_required
-def organization_settings_update_logo():
+def organization_settings_add_logo():
     logger.info("Attemping to update organization logo")
     installation = current_user.installation
     slack = SlackClient(installation.bot_access_token)

--- a/busy_beaver/templates/base.html
+++ b/busy_beaver/templates/base.html
@@ -1,3 +1,5 @@
+{% from "bootstrap/utils.html" import render_messages %}
+
 <!doctype html>
 <html lang="en">
 
@@ -47,6 +49,8 @@
   </nav>
 
   <div id="main" class="container">
+    {{ render_messages(dismissible=True) }}
+
     {% block container %}
     {% endblock %}
   </div>

--- a/busy_beaver/templates/organization_settings.html
+++ b/busy_beaver/templates/organization_settings.html
@@ -37,7 +37,7 @@
     </small>
   </p>
 {% else %}
-  <form method="POST" action="{{ url_for('web.organization_settings_update_logo') }}" enctype="multipart/form-data">
+  <form method="POST" action="{{ url_for('web.organization_settings_add_logo') }}" enctype="multipart/form-data">
     {{ logo_form.csrf_token }}
     {{ render_field(logo_form.logo) }}
 

--- a/tests/apps/web/test_views.py
+++ b/tests/apps/web/test_views.py
@@ -307,7 +307,7 @@ class TestUpdateOrganizationSettings:
         client = login_client(user=slack_user)
         rv = client.post(
             "/settings/organization/logo",
-            data={"logo": (logo_file, f"testfile.txt")},
+            data={"logo": (logo_file, "testfile.txt")},
             follow_redirects=True,
             content_type="multipart/form-data",
         )

--- a/tests/apps/web/test_views.py
+++ b/tests/apps/web/test_views.py
@@ -64,10 +64,10 @@ class TestUpcomingEventsViews:
     def test_upcoming_events_get(self, login_client, factory, patch_slack):
         # Arrange
         slack_user = factory.SlackUser()
-        client = login_client(user=slack_user)
         patch_slack(is_admin=True)
 
         # Act
+        client = login_client(user=slack_user)
         rv = client.get("/settings/upcoming-events", follow_redirects=True)
 
         # Assert
@@ -79,10 +79,10 @@ class TestUpcomingEventsViews:
     ):
         # Arrange
         slack_user = factory.SlackUser()
-        client = login_client(user=slack_user)
         patch_slack(is_admin=True)
 
         # Act
+        client = login_client(user=slack_user)
         rv = client.get("/settings/upcoming-events/group", follow_redirects=True)
 
         # Assert
@@ -96,10 +96,10 @@ class TestUpcomingEventsViews:
         # Arrange
         config = factory.UpcomingEventsConfiguration(enabled=True)
         slack_user = factory.SlackUser(installation=config.slack_installation)
-        client = login_client(user=slack_user)
         patch_slack(is_admin=True)
 
         # Act
+        client = login_client(user=slack_user)
         rv = client.post(
             "/settings/upcoming-events/group",
             data={"meetup_urlname": "_CHIPY_"},
@@ -120,10 +120,10 @@ class TestUpcomingEventsViews:
         # Arrange
         config = factory.UpcomingEventsConfiguration(enabled=True)
         slack_user = factory.SlackUser(installation=config.slack_installation)
-        client = login_client(user=slack_user)
         patch_slack(is_admin=True)
 
         # Act
+        client = login_client(user=slack_user)
         rv = client.post(
             "/settings/upcoming-events/group",
             data={"meetup_urlname": "adsfasdfeum3n4x"},
@@ -145,10 +145,10 @@ class TestUpcomingEventsViews:
         config = factory.UpcomingEventsConfiguration(enabled=True)
         UpcomingEventsGroup(meetup_urlname="_ChiPy_", configuration=config)
         slack_user = factory.SlackUser(installation=config.slack_installation)
-        client = login_client(user=slack_user)
         patch_slack(is_admin=True)
 
         # Act
+        client = login_client(user=slack_user)
         rv = client.post(
             "/settings/upcoming-events/group",
             data={"meetup_urlname": "_ChiPy_"},
@@ -169,10 +169,10 @@ class TestUpcomingEventsViews:
         # Arrange
         config = factory.UpcomingEventsConfiguration(enabled=True)
         slack_user = factory.SlackUser(installation=config.slack_installation)
-        client = login_client(user=slack_user)
         patch_slack(is_admin=True)
 
         # Act
+        client = login_client(user=slack_user)
         rv = client.get("/settings/upcoming-events/toggle", follow_redirects=True)
 
         # Assert
@@ -187,10 +187,10 @@ class TestUpcomingEventsViews:
         config = factory.UpcomingEventsConfiguration(enabled=True)
         group = UpcomingEventsGroup(meetup_urlname="_ChiPy_", configuration=config)
         slack_user = factory.SlackUser(installation=config.slack_installation)
-        client = login_client(user=slack_user)
         patch_slack(is_admin=True)
 
         # Act
+        client = login_client(user=slack_user)
         rv = client.get(
             f"/settings/upcoming-events/group/{group.id}/delete", follow_redirects=True
         )
@@ -208,10 +208,10 @@ class TestUpcomingEventsViews:
         # Arrange
         config = factory.UpcomingEventsConfiguration(post_cron_enabled=start_state)
         slack_user = factory.SlackUser(installation=config.slack_installation)
-        client = login_client(user=slack_user)
         patch_slack(is_admin=True)
 
         # Act
+        client = login_client(user=slack_user)
         rv = client.get(
             "/settings/upcoming-events/post-cron/toggle", follow_redirects=True
         )
@@ -228,10 +228,10 @@ class TestUpdateOrganizationSettings:
     def test_load_organization_settings_page(self, login_client, factory, patch_slack):
         # Arrange
         slack_user = factory.SlackUser()
-        client = login_client(user=slack_user)
         patch_slack(is_admin=True)
 
         # Act
+        client = login_client(user=slack_user)
         rv = client.get("/settings/organization")
 
         # Assert
@@ -242,10 +242,10 @@ class TestUpdateOrganizationSettings:
         # Arrange
         installation = factory.SlackInstallation(workspace_name="ChiPy")
         slack_user = factory.SlackUser(installation=installation)
-        client = login_client(user=slack_user)
         patch_slack(is_admin=True)
 
         # Act
+        client = login_client(user=slack_user)
         rv = client.post(
             "/settings/organization",
             data={"organization_name": "Chicago Python"},
@@ -258,22 +258,24 @@ class TestUpdateOrganizationSettings:
         assert installation.organization_name == "Chicago Python"
 
     @pytest.mark.end2end
+    # TODO add pytest.parametrize for all the allowed file types
+    # TODO add test for .txt filetype.... does not
     def test_add_organization_logo(self, s3, login_client, factory, patch_slack):
         # Arrange
         installation = factory.SlackInstallation(
             workspace_name="ChiPy", workspace_logo_url=None
         )
         slack_user = factory.SlackUser(installation=installation)
-        client = login_client(user=slack_user)
         patch_slack(is_admin=True)
 
         logo_bytes = b"abcdefghijklmnopqrstuvwxyz"
         logo_file = io.BytesIO(logo_bytes)
 
         # Act
+        client = login_client(user=slack_user)
         rv = client.post(
             "/settings/organization/logo",
-            data={"logo": (logo_file, "testfile.txt")},
+            data={"logo": (logo_file, "testfile.jpg")},
             follow_redirects=True,
             content_type="multipart/form-data",
         )
@@ -281,7 +283,7 @@ class TestUpdateOrganizationSettings:
         # Assert
         assert rv.status_code == 200
         installation = SlackInstallation.query.first()
-        assert ".txt" in installation.workspace_logo_url
+        assert ".jpg" in installation.workspace_logo_url
 
     @pytest.mark.end2end
     def test_remove_organization_logo(self, login_client, factory, patch_slack):
@@ -291,11 +293,11 @@ class TestUpdateOrganizationSettings:
             workspace_logo_url="http://www.google.com/images/image.jpg",
         )
         slack_user = factory.SlackUser(installation=installation)
-        client = login_client(user=slack_user)
         patch_slack(is_admin=True)
 
         # Act
-        rv = client.get("/settings/organization/logo/remove")
+        client = login_client(user=slack_user)
+        rv = client.get("/settings/organization/logo/remove", follow_redirects=True)
 
         # Assert
         assert rv.status_code == 200


### PR DESCRIPTION
Closes #303 

### What does this do

We were using `jsonify` to pass information back to the user. This was a hack until we figured out how to add messages to our flask templates.

Restrict the file types users can upload to `.jpg`, `.jpeg`, `.png`

### Why are we doing this

Improve user experience

### How should this be tested

Tested locally to see if messages come thru; it's good

### Migrations

n/a

### Dependencies

n/a

### Callouts

n/a