### PR TITLE
Merge dictionaries using new operator in Python 3.9

### DIFF
--- a/busy_beaver/common/wrappers/github.py
+++ b/busy_beaver/common/wrappers/github.py
@@ -67,8 +67,7 @@ class GitHubClient:
 
         all_items = []
         for page_num in range(1, min(last_page, max_pages) + 1):
-            combined_params = self.params.copy()
-            combined_params.update({"page": page_num})
+            combined_params = self.params | {"page": page_num}
             resp = self.__get(url, params=combined_params)
             all_items.extend(resp.json)
 
@@ -80,8 +79,7 @@ class GitHubClient:
         page_num = 1
 
         while True:
-            combined_params = self.params.copy()
-            combined_params.update({"page": page_num})
+            combined_params = self.params | {"page": page_num}
             resp = self.__get(url, params=combined_params)
             all_items.extend(resp.json)
 

--- a/busy_beaver/common/wrappers/requests_client.py
+++ b/busy_beaver/common/wrappers/requests_client.py
@@ -22,13 +22,11 @@ class RequestsClient:
     """Wrapper around requests to simplify interaction with JSON REST APIs"""
 
     def __init__(self, headers: dict = None, raise_for_status: bool = True):
-        _headers = dict(DEFAULT_HEADERS)
-        if headers is not None:
-            _headers.update(headers)
+        if headers is None:
+            headers = {}
 
-        s = requests.Session()
-        self.headers = _headers
-        self.session = s
+        self.session = requests.Session()
+        self.headers = DEFAULT_HEADERS | headers
         self.raise_for_status = raise_for_status
 
     def __repr__(self):  # pragma: no cover
@@ -44,11 +42,8 @@ class RequestsClient:
         return self._request("post", url, **kwargs)
 
     def _request(self, method: str, url: str, **kwargs) -> Response:
-        req_headers = dict(self.headers)
-        if "headers" in kwargs:
-            headers_to_add = kwargs.pop("headers")
-            req_headers.update(headers_to_add)
-
+        headers_to_add = kwargs.pop("headers", {})
+        req_headers = self.headers | headers_to_add
         r = self.session.request(method, url, headers=req_headers, **kwargs)
         if self.raise_for_status:
             r.raise_for_status()


### PR DESCRIPTION
Closes #110 

### What does this do

Using [new dictionary update operator](https://docs.python.org/3/whatsnew/3.9.html#dictionary-merge-update-operators) in Python 3.9 to clean up code.

### Why are we doing this

Makes everything a bit more readable.

### How should this be tested

do tests pass? then we are good

### Migrations

n/a

### Dependencies

n/a

### Callouts

n/a