### PR TITLE
Upgrade testing dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Busy Beaver
-
 <p align="center"><img src="assets/logo.png" alt="Busy Beaver Logo" width=300 /></p>
+
+# Busy Beaver
 
 ![build status](https://github.com/busy-beaver-dev/busy-beaver/workflows/build/badge.svg?branch=master&event=push)
 [![codecov](https://codecov.io/gh/busy-beaver-dev/busy-beaver/branch/master/graph/badge.svg)](https://codecov.io/gh/busy-beaver-dev/busy-beaver)

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,7 @@
 alembic==1.3.2
 bootstrap-flask==1.4
 boto3==1.15.0
+click==7.1.2                        # required for black (dev dependency)
 cryptography==3.2
 factory_boy==2.12.0
 finite-state-machine==0.2.0

--- a/requirements.in
+++ b/requirements.in
@@ -38,6 +38,6 @@ pytest-freezegun==0.3.0.post1
 pytest-mock==2.0.0
 pytest-sugar==0.9.2
 pytest-vcr==1.0.2
-pytest==5.3.2
+pytest==6.1.2
 responses==0.10.9
 vcrpy==4.0.2

--- a/requirements.in
+++ b/requirements.in
@@ -31,3 +31,13 @@ werkzeug==0.16.0
 whitenoise==5.0.1                   # serving static files quickly; use until we need a CDN
 wtforms==2.3.1
 WTForms-Components==0.10.4
+
+# tests
+pytest-cov==2.8.1
+pytest-freezegun==0.3.0.post1
+pytest-mock==2.0.0
+pytest-sugar==0.9.2
+pytest-vcr==1.0.2
+pytest==5.3.2
+responses==0.10.9
+vcrpy==4.0.2

--- a/requirements.in
+++ b/requirements.in
@@ -34,11 +34,11 @@ wtforms==2.3.1
 WTForms-Components==0.10.4
 
 # tests
-pytest-cov==2.8.1
-pytest-freezegun==0.3.0.post1
-pytest-mock==2.0.0
-pytest-sugar==0.9.2
+pytest-cov==2.10.1
+pytest-freezegun==0.4.2
+pytest-mock==3.3.1
+pytest-sugar==0.9.4
 pytest-vcr==1.0.2
 pytest==6.1.2
-responses==0.10.9
-vcrpy==4.0.2
+responses==0.12.0
+vcrpy==4.1.1

--- a/requirements.in
+++ b/requirements.in
@@ -3,7 +3,6 @@ bootstrap-flask==1.4
 boto3==1.15.0
 click==7.1.2                        # required for black (dev dependency)
 cryptography==3.2
-factory_boy==2.12.0
 finite-state-machine==0.2.0
 flask-login==0.5.0
 Flask-Migrate==2.5.2
@@ -33,7 +32,8 @@ whitenoise==5.0.1                   # serving static files quickly; use until we
 wtforms==2.3.1
 WTForms-Components==0.10.4
 
-# tests
+# testing dependencies
+factory_boy==3.1.0
 pytest-cov==2.10.1
 pytest-freezegun==0.4.2
 pytest-mock==3.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,6 +37,7 @@ gunicorn==20.0.4          # via -r requirements.in
 idna==2.7                 # via requests, yarl
 infinity==1.5             # via intervals
 inflect==2.1.0            # via -r requirements.in
+iniconfig==1.1.1          # via pytest
 intervals==0.8.1          # via wtforms-components
 ipython-genutils==0.2.0   # via traitlets
 ipython==7.18.1           # via -r requirements.in, flask-shell-ipython
@@ -47,7 +48,6 @@ jmespath==0.10.0          # via boto3, botocore
 mako==1.0.12              # via alembic
 markupsafe==1.1.1         # via jinja2, mako, wtforms
 marshmallow==3.3.0        # via -r requirements.in
-more-itertools==8.5.0     # via pytest
 multidict==4.5.2          # via aiohttp, yarl
 oauthlib==3.0.1           # via requests-oauthlib
 packaging==20.4           # via pytest, pytest-sugar
@@ -67,7 +67,7 @@ pytest-freezegun==0.3.0.post1  # via -r requirements.in
 pytest-mock==2.0.0        # via -r requirements.in
 pytest-sugar==0.9.2       # via -r requirements.in
 pytest-vcr==1.0.2         # via -r requirements.in
-pytest==5.3.2             # via -r requirements.in, pytest-cov, pytest-freezegun, pytest-mock, pytest-sugar, pytest-vcr
+pytest==6.1.2             # via -r requirements.in, pytest-cov, pytest-freezegun, pytest-mock, pytest-sugar, pytest-vcr
 python-dateutil==2.8.1    # via -r requirements.in, alembic, botocore, faker, freezegun
 python-editor==1.0.4      # via alembic
 python-json-logger==0.1.11  # via -r requirements.in
@@ -88,11 +88,12 @@ sqlalchemy-utils==0.36.1  # via -r requirements.in
 sqlalchemy==1.3.12        # via -r requirements.in, alembic, flask-sqlalchemy, sqlalchemy-utils
 termcolor==1.1.0          # via pytest-sugar
 text-unidecode==1.2       # via faker
+toml==0.10.1              # via pytest
 traitlets==5.0.5          # via ipython
 urllib3==1.24.3           # via botocore, requests, sentry-sdk
 validators==0.15.0        # via wtforms-components
 vcrpy==4.0.2              # via -r requirements.in, pytest-vcr
-wcwidth==0.2.5            # via prompt-toolkit, pytest
+wcwidth==0.2.5            # via prompt-toolkit
 werkzeug==0.16.0          # via -r requirements.in, flask
 whitenoise==5.0.1         # via -r requirements.in
 wrapt==1.12.1             # via vcrpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ botocore==1.18.0          # via boto3, s3transfer
 certifi==2019.3.9         # via requests, sentry-sdk
 cffi==1.12.3              # via cryptography
 chardet==3.0.4            # via aiohttp, requests
-click==7.0                # via flask, flask-shell-ipython, rq
+click==7.1.2              # via -r requirements.in, flask, flask-shell-ipython, rq
 coverage==5.3             # via pytest-cov
 croniter==0.3.30          # via rq-scheduler
 cryptography==3.2         # via -r requirements.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ aiohttp==3.5.4            # via slackclient
 alembic==1.3.2            # via -r requirements.in, flask-migrate
 appnope==0.1.0            # via ipython
 async-timeout==3.0.1      # via aiohttp
-attrs==19.1.0             # via aiohttp
+attrs==19.1.0             # via aiohttp, pytest
 backcall==0.2.0           # via ipython
 blinker==1.4              # via sentry-sdk
 bootstrap-flask==1.4      # via -r requirements.in
@@ -18,6 +18,7 @@ certifi==2019.3.9         # via requests, sentry-sdk
 cffi==1.12.3              # via cryptography
 chardet==3.0.4            # via aiohttp, requests
 click==7.0                # via flask, flask-shell-ipython, rq
+coverage==5.3             # via pytest-cov
 croniter==0.3.30          # via rq-scheduler
 cryptography==3.2         # via -r requirements.in
 decorator==4.4.2          # via ipython, validators
@@ -31,6 +32,7 @@ flask-shell-ipython==0.4.1  # via -r requirements.in
 flask-sqlalchemy==2.4.1   # via -r requirements.in, flask-migrate
 flask-wtf==0.14.3         # via -r requirements.in
 flask==1.1.1              # via -r requirements.in, bootstrap-flask, flask-login, flask-migrate, flask-rq2, flask-shell-ipython, flask-sqlalchemy, flask-wtf, sentry-sdk
+freezegun==1.0.0          # via pytest-freezegun
 gunicorn==20.0.4          # via -r requirements.in
 idna==2.7                 # via requests, yarl
 infinity==1.5             # via intervals
@@ -45,42 +47,58 @@ jmespath==0.10.0          # via boto3, botocore
 mako==1.0.12              # via alembic
 markupsafe==1.1.1         # via jinja2, mako, wtforms
 marshmallow==3.3.0        # via -r requirements.in
+more-itertools==8.5.0     # via pytest
 multidict==4.5.2          # via aiohttp, yarl
 oauthlib==3.0.1           # via requests-oauthlib
+packaging==20.4           # via pytest, pytest-sugar
 parso==0.7.1              # via jedi
 pexpect==4.8.0            # via ipython
 pickleshare==0.7.5        # via ipython
+pluggy==0.13.1            # via pytest
 prompt-toolkit==3.0.8     # via ipython
 psycopg2-binary==2.8.4    # via -r requirements.in
 ptyprocess==0.6.0         # via pexpect
+py==1.9.0                 # via pytest
 pycparser==2.19           # via cffi
 pygments==2.7.2           # via ipython
-python-dateutil==2.8.1    # via -r requirements.in, alembic, botocore, croniter, faker
+pyparsing==2.4.7          # via packaging
+pytest-cov==2.8.1         # via -r requirements.in
+pytest-freezegun==0.3.0.post1  # via -r requirements.in
+pytest-mock==2.0.0        # via -r requirements.in
+pytest-sugar==0.9.2       # via -r requirements.in
+pytest-vcr==1.0.2         # via -r requirements.in
+pytest==5.3.2             # via -r requirements.in, pytest-cov, pytest-freezegun, pytest-mock, pytest-sugar, pytest-vcr
+python-dateutil==2.8.1    # via -r requirements.in, alembic, botocore, faker, freezegun
 python-editor==1.0.4      # via alembic
 python-json-logger==0.1.11  # via -r requirements.in
 pytz==2020.1              # via -r requirements.in
+pyyaml==5.3.1             # via vcrpy
 redis==3.4.1              # via -r requirements.in, flask-rq2, rq
 requests-oauthlib==1.3.0  # via -r requirements.in
-requests==2.22.0          # via -r requirements.in, requests-oauthlib
+requests==2.22.0          # via -r requirements.in, requests-oauthlib, responses
+responses==0.10.9         # via -r requirements.in
 rq-scheduler==0.9         # via flask-rq2
 rq==1.0                   # via flask-rq2, rq-scheduler
 s3transfer==0.3.3         # via boto3
 secure==0.2.1             # via -r requirements.in
 sentry-sdk[flask]==0.14.0  # via -r requirements.in
-six==1.12.0               # via cryptography, faker, python-dateutil, sqlalchemy-utils, validators, wtforms-components
+six==1.12.0               # via cryptography, faker, packaging, python-dateutil, responses, sqlalchemy-utils, validators, vcrpy, wtforms-components
 slackclient==2.5.0        # via -r requirements.in
 sqlalchemy-utils==0.36.1  # via -r requirements.in
 sqlalchemy==1.3.12        # via -r requirements.in, alembic, flask-sqlalchemy, sqlalchemy-utils
+termcolor==1.1.0          # via pytest-sugar
 text-unidecode==1.2       # via faker
 traitlets==5.0.5          # via ipython
 urllib3==1.24.3           # via botocore, requests, sentry-sdk
 validators==0.15.0        # via wtforms-components
-wcwidth==0.2.5            # via prompt-toolkit
+vcrpy==4.0.2              # via -r requirements.in, pytest-vcr
+wcwidth==0.2.5            # via prompt-toolkit, pytest
 werkzeug==0.16.0          # via -r requirements.in, flask
 whitenoise==5.0.1         # via -r requirements.in
+wrapt==1.12.1             # via vcrpy
 wtforms-components==0.10.4  # via -r requirements.in
 wtforms==2.3.1            # via -r requirements.in, flask-wtf, wtforms-components
-yarl==1.3.0               # via aiohttp
+yarl==1.3.0               # via aiohttp, vcrpy
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -62,10 +62,10 @@ py==1.9.0                 # via pytest
 pycparser==2.19           # via cffi
 pygments==2.7.2           # via ipython
 pyparsing==2.4.7          # via packaging
-pytest-cov==2.8.1         # via -r requirements.in
-pytest-freezegun==0.3.0.post1  # via -r requirements.in
-pytest-mock==2.0.0        # via -r requirements.in
-pytest-sugar==0.9.2       # via -r requirements.in
+pytest-cov==2.10.1        # via -r requirements.in
+pytest-freezegun==0.4.2   # via -r requirements.in
+pytest-mock==3.3.1        # via -r requirements.in
+pytest-sugar==0.9.4       # via -r requirements.in
 pytest-vcr==1.0.2         # via -r requirements.in
 pytest==6.1.2             # via -r requirements.in, pytest-cov, pytest-freezegun, pytest-mock, pytest-sugar, pytest-vcr
 python-dateutil==2.8.1    # via -r requirements.in, alembic, botocore, faker, freezegun
@@ -76,7 +76,7 @@ pyyaml==5.3.1             # via vcrpy
 redis==3.4.1              # via -r requirements.in, flask-rq2, rq
 requests-oauthlib==1.3.0  # via -r requirements.in
 requests==2.22.0          # via -r requirements.in, requests-oauthlib, responses
-responses==0.10.9         # via -r requirements.in
+responses==0.12.0         # via -r requirements.in
 rq-scheduler==0.9         # via flask-rq2
 rq==1.0                   # via flask-rq2, rq-scheduler
 s3transfer==0.3.3         # via boto3
@@ -90,9 +90,9 @@ termcolor==1.1.0          # via pytest-sugar
 text-unidecode==1.2       # via faker
 toml==0.10.1              # via pytest
 traitlets==5.0.5          # via ipython
-urllib3==1.24.3           # via botocore, requests, sentry-sdk
+urllib3==1.25.11          # via botocore, requests, responses, sentry-sdk
 validators==0.15.0        # via wtforms-components
-vcrpy==4.0.2              # via -r requirements.in, pytest-vcr
+vcrpy==4.1.1              # via -r requirements.in, pytest-vcr
 wcwidth==0.2.5            # via prompt-toolkit
 werkzeug==0.16.0          # via -r requirements.in, flask
 whitenoise==5.0.1         # via -r requirements.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ coverage==5.3             # via pytest-cov
 croniter==0.3.30          # via rq-scheduler
 cryptography==3.2         # via -r requirements.in
 decorator==4.4.2          # via ipython, validators
-factory_boy==2.12.0       # via -r requirements.in
+factory_boy==3.1.0        # via -r requirements.in
 faker==1.0.7              # via factory-boy
 finite-state-machine==0.2.0  # via -r requirements.in
 flask-login==0.5.0        # via -r requirements.in

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,11 +5,3 @@ isort
 pdbpp
 pip-tools
 pre-commit==1.14.4
-pytest-cov==2.8.1
-pytest-freezegun==0.3.0.post1
-pytest-mock==2.0.0
-pytest-sugar==0.9.2
-pytest-vcr==1.0.2
-pytest==5.3.2
-responses==0.10.9
-vcrpy==4.0.2

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,4 +4,4 @@ flake8
 isort
 pdbpp
 pip-tools
-pre-commit==1.14.4
+pre-commit==2.8.1


### PR DESCRIPTION
### What does this do

- move testing dependencies from `requirements_dev.txt` to `requirements.txt`
- upgrade pytest to 6.x.x and upgrade all other testing deps

### Why are we doing this

Testings deps are part of the codebase; they are not development dependentcies

### How should this be tested

do tests still pass?

### Migrations

n/a

### Dependencies

n/a

### Callouts

n/a