### PR TITLE
Run post_github_summary_message coroutine via RQ

### DIFF
--- a/busy_beaver/apps/debug/workflows.py
+++ b/busy_beaver/apps/debug/workflows.py
@@ -6,19 +6,30 @@ def add(x, y):
     return x + y
 
 
+@rq.job
+async def add_async(x, y):
+    return x + y
+
+
 """
 # How to debug
 
 make flaskshell
 
 from datetime import timedelta
-from busy_beaver.apps.debug.workflows import add
+from busy_beaver.apps.debug.workflows import add, add_async
 
 
 job = add.queue(3, 4)
 job.result
 
-job = add.schedule(timedelta(seconds=5), 1, 2)
+job = add_async.schedule(timedelta(seconds=5), 1, 2)
+job.result
+
+job = add.queue(3, 4)
+job.result
+
+job = add_async.schedule(timedelta(seconds=5), 1, 2)
 job.result
 """
 # app.config['RQ_SCHEDULER_QUEUE'] = 'scheduled'

--- a/busy_beaver/common/wrappers/github.py
+++ b/busy_beaver/common/wrappers/github.py
@@ -40,9 +40,10 @@ class GitHubClient:
 
 class AsyncGitHubClient:
     def __init__(self, oauth_token: str):
-        self.headers = {  # TODO: use this
+        self.headers = {
             "Accept": "application/vnd.github.v3+json",
             "Authorization": f"token {oauth_token}",
+            "User-Agent": "BusyBeaver -- GitHub Client",
         }
         self.params = {"per_page": 30}
         self.nav = None

--- a/busy_beaver/common/wrappers/github.py
+++ b/busy_beaver/common/wrappers/github.py
@@ -61,12 +61,6 @@ class AsyncGitHubClient:
         start_dt: datetime,
         end_dt: datetime,
     ) -> Dict[str, list]:
-        """
-        Entry point for clients;
-        kicks off fetching user activity from GitHub API using asyncio
-
-        Is there a cleaner way to do this?
-        """
         async with self._create_async_client() as client:
             tasks = []
             for user in users:

--- a/busy_beaver/common/wrappers/github.py
+++ b/busy_beaver/common/wrappers/github.py
@@ -21,8 +21,6 @@ class GitHubClient:
             "Authorization": f"token {oauth_token}",
         }
         self.client = RequestsClient(headers=default_headers)
-        self.params = {"per_page": 30}
-        self.nav = None
 
     def __repr__(self):  # pragma: no cover
         return "GitHubAdapter"
@@ -46,7 +44,6 @@ class AsyncGitHubClient:
             "User-Agent": "BusyBeaver -- GitHub Client",
         }
         self.params = {"per_page": 30}
-        self.nav = None
 
     def __repr__(self):  # pragma: no cover
         return "AsyncGitHubAdapter"

--- a/busy_beaver/common/wrappers/github.py
+++ b/busy_beaver/common/wrappers/github.py
@@ -55,7 +55,7 @@ class AsyncGitHubClient:
         """Generate client used for making asynchronous requests"""
         return httpx.AsyncClient(headers=self.headers, params=self.params)
 
-    def get_activity_for_users(
+    async def get_activity_for_users(
         self,
         users: List[str],
         start_dt: datetime,
@@ -67,15 +67,6 @@ class AsyncGitHubClient:
 
         Is there a cleaner way to do this?
         """
-        task = self._get_activity_for_users(users, start_dt, end_dt)
-        return asyncio.run(task)
-
-    async def _get_activity_for_users(
-        self,
-        users: List[str],
-        start_dt: datetime,
-        end_dt: datetime,  # comma separated list
-    ) -> Dict[str, list]:
         async with self._create_async_client() as client:
             tasks = []
             for user in users:

--- a/requirements.in
+++ b/requirements.in
@@ -20,9 +20,10 @@ psycopg2-binary==2.8.4
 python-dateutil==2.8.1
 python-json-logger==0.1.11
 pytz==2020.1
-redis==3.4.1
+redis==3.5.3
 requests-oauthlib==1.3.0
 requests==2.22.0
+rq==1.9
 secure==0.2.1
 sentry-sdk[flask]==0.14.0
 slackclient==2.5.0

--- a/requirements.in
+++ b/requirements.in
@@ -36,6 +36,7 @@ WTForms-Components==0.10.4
 
 # testing dependencies
 factory_boy==3.1.0
+pytest-asyncio==0.15.1
 pytest-cov==2.10.1
 pytest-freezegun==0.4.2
 pytest-mock==3.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -81,13 +81,13 @@ python-editor==1.0.4      # via alembic
 python-json-logger==0.1.11  # via -r requirements.in
 pytz==2020.1              # via -r requirements.in
 pyyaml==5.3.1             # via vcrpy
-redis==3.4.1              # via -r requirements.in, flask-rq2, rq
+redis==3.5.3              # via -r requirements.in, flask-rq2, rq
 requests-oauthlib==1.3.0  # via -r requirements.in
 requests==2.22.0          # via -r requirements.in, requests-oauthlib, responses
 responses==0.12.0         # via -r requirements.in
 rfc3986[idna2008]==1.5.0  # via httpx
 rq-scheduler==0.9         # via flask-rq2
-rq==1.0                   # via flask-rq2, rq-scheduler
+rq==1.9.0                 # via -r requirements.in, flask-rq2, rq-scheduler
 s3transfer==0.3.3         # via boto3
 secure==0.2.1             # via -r requirements.in
 sentry-sdk[flask]==0.14.0  # via -r requirements.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -70,12 +70,13 @@ py==1.9.0                 # via pytest
 pycparser==2.19           # via cffi
 pygments==2.7.2           # via ipython
 pyparsing==2.4.7          # via packaging
+pytest-asyncio==0.15.1    # via -r requirements.in
 pytest-cov==2.10.1        # via -r requirements.in
 pytest-freezegun==0.4.2   # via -r requirements.in
 pytest-mock==3.3.1        # via -r requirements.in
 pytest-sugar==0.9.4       # via -r requirements.in
 pytest-vcr==1.0.2         # via -r requirements.in
-pytest==6.1.2             # via -r requirements.in, pytest-cov, pytest-freezegun, pytest-mock, pytest-sugar, pytest-vcr
+pytest==6.1.2             # via -r requirements.in, pytest-asyncio, pytest-cov, pytest-freezegun, pytest-mock, pytest-sugar, pytest-vcr
 python-dateutil==2.8.1    # via -r requirements.in, alembic, botocore, croniter, faker, freezegun
 python-editor==1.0.4      # via alembic
 python-json-logger==0.1.11  # via -r requirements.in

--- a/tests/apps/github_integration/summary/test_workflow.py
+++ b/tests/apps/github_integration/summary/test_workflow.py
@@ -30,7 +30,8 @@ def patched_slack(patcher):
 class TestPostGitHubSummaryMessage:
     @pytest.mark.vcr
     @pytest.mark.freeze_time("2021-08-28")
-    def test_active_users_have_summary_generated(
+    @pytest.mark.asyncio
+    async def test_active_users_have_summary_generated(
         self,
         session,
         factory,
@@ -53,7 +54,7 @@ class TestPostGitHubSummaryMessage:
         slack = patched_slack(members=[slack_user1, "user2"])
 
         # Act -- run function
-        post_github_summary_message(workspace_id=slack_installation.workspace_id)
+        await post_github_summary_message(workspace_id=slack_installation.workspace_id)
 
         # Assert -- message sent to slack has activity to report
         slack_adapter_initalize_args = slack.mock.call_args_list[0]
@@ -68,7 +69,8 @@ class TestPostGitHubSummaryMessage:
 
     @pytest.mark.vcr
     @pytest.mark.freeze_time("2021-08-28")
-    def test_inactive_users_results_in_no_activity_to_report(
+    @pytest.mark.asyncio
+    async def test_inactive_users_results_in_no_activity_to_report(
         self,
         session,
         factory,
@@ -91,7 +93,7 @@ class TestPostGitHubSummaryMessage:
         slack = patched_slack(members=["user78", "user34"])
 
         # Act -- run function
-        post_github_summary_message(workspace_id=slack_installation.workspace_id)
+        await post_github_summary_message(workspace_id=slack_installation.workspace_id)
 
         # Assert -- message sent to slack has no activity to report
         slack_adapter_initalize_args = slack.mock.call_args_list[0]

--- a/tests/common/wrappers/test_github.py
+++ b/tests/common/wrappers/test_github.py
@@ -33,13 +33,18 @@ class TestGitHubClient:
 class TestAsyncGitHubClient:
     @pytest.mark.vcr()
     @pytest.mark.freeze_time("2021-08-28")
-    def test_get_activity_for_users(self, async_github_client):
+    @pytest.mark.asyncio
+    async def test_get_activity_for_users(self, async_github_client):
         # Arrange -- create 1 real github user, 1 fake user
         usernames = ["alysivji", "albcae324sdf"]
 
         # Arrange -- time period we are searching for
         start_dt, end_dt = generate_range_utc_now_minus(timedelta(days=1))
-        result = async_github_client.get_activity_for_users(usernames, start_dt, end_dt)
+
+        # Act
+        result = await async_github_client.get_activity_for_users(
+            usernames, start_dt, end_dt
+        )
 
         # Assert -- data was pulled for valid users
         assert result.keys() == set(["alysivji"])

--- a/tests/smoke/test_redis.py
+++ b/tests/smoke/test_redis.py
@@ -21,7 +21,7 @@ def test_async_task_called_like_regular_function(app, rq):
 
 
 @pytest.mark.smoke
-def test_run_async_task(app, rq):
+def test_run_regular_function_via_rq(app, rq):
     rq.job(add)
     job = add.queue(5, 2)
     assert job.result == 7
@@ -32,8 +32,19 @@ def exception_function():
 
 
 @pytest.mark.smoke
-def test_run_async_task_raising_exception(app, rq):
+def test_run_exception_function_via_rq(app, rq):
     rq.job(exception_function)
 
     with pytest.raises(ValueError):
         exception_function.queue()
+
+
+async def add_coroutine(x, y):
+    return x + y
+
+
+@pytest.mark.smoke
+def test_run_coroutine_via_rq(app, rq):
+    rq.job(add_coroutine)
+    job = add_coroutine.queue(5, 2)
+    assert job.result == 7


### PR DESCRIPTION
### What does this do

- take advantage of [new RQ feature to run coroutines on workers processes](https://github.com/rq/rq/releases/tag/v1.8.0)
  - looked thru the code; RQ forks a process and then executes the queued task in the child process so this is a safe change
- run `post_github_summary_message` via RQ

### Why are we doing this

Don't have to manually queue up coroutines via asyncio. Results in a cleaner API

### How should this be tested

Added pytest-asyncio to make it easier to test coroutines

### Migrations

n/a

### Dependencies

n/a

### Callouts

n/a
